### PR TITLE
clickhouse: add multiline to promtail logging

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/observIQ/charts
-version: 3.2.3
+version: 3.2.4
 maintainers:
   - name: observIQ

--- a/charts/clickhouse/templates/promtail-config.yaml
+++ b/charts/clickhouse/templates/promtail-config.yaml
@@ -19,4 +19,9 @@ data:
         labels:
           instance: ${INSTANCE}:9363
           job: integrations/clickhouse
-          __path__: /var/log/clickhouse-server/*err.log
+          __path__: /var/log/clickhouse-server/clickhouse-server.err.log
+      pipeline_stages:
+      - multiline:
+          firstline: '^([\d]{4}).([\d]{1,2}).([\d]{1,2}) (([\d]+):([\d]+):([\d]+).([\d]+))'
+      - regex:
+          expression: '(?P<timestamp>(([\d]{4}).([\d]{1,2}).([\d]{1,2}) (([\d]+):([\d]+):([\d]+).([\d]+))) (?P<message>(?s:.*))$)'


### PR DESCRIPTION
Added multiline error logs so all stack trace gets grouped together. Also changes __path__ to be same as the [agent.jsonnet](https://github.com/observIQ/cloud-onboarding/pull/20/files#diff-68058b0f23db42b1d15cb51ef8fd127a06ce86764a12c75f6239b340d6137239R23)

Before:
![](https://user-images.githubusercontent.com/14870891/203539407-27abbd4b-f4bd-4113-a93d-6e1a6c0520ab.png)

After:
![Screen Shot 2022-11-30 at 12 05 39 PM](https://user-images.githubusercontent.com/13648435/204862007-0dd622f6-851b-4d0c-ae25-d0b3fd26162d.png)
