### PR TITLE
Updated wildfly container bind addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ If you had already added this repo earlier, run `helm repo update` to retrieve
 the latest versions of the packages.  You can then run `helm search repo
 observiq` to see the charts.
 
+### Updating container images
+
+1. Open PR for changes to container image
+2. Approve and merge PR
+3. Watch main branch CI. It will build and push the image. The CI output will usually have the image tag.
+4. Open another PR changing the image used by the helm chart. Be sure to update the chart version.
+5. Approve and merge
+6. CI will release the helm chart
+7. Update your local helm repo to get the new chart version, which will have your new image.
+
 ### Applications
 
 #### Clickhouse

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ observiq` to see the charts.
 ### Updating container images
 
 1. Open PR for changes to container image
-2. Approve and merge PR
+2. Request a review. Once approved, merge PR
 3. Watch main branch CI. It will build and push the image. The CI output will usually have the image tag.
 4. Open another PR changing the image used by the helm chart. Be sure to update the chart version.
-5. Approve and merge
+5. Request a review. Once approved, merge PR
 6. CI will release the helm chart
 7. Update your local helm repo to get the new chart version, which will have your new image.
 

--- a/container/wildfly/standalone.xml
+++ b/container/wildfly/standalone.xml
@@ -507,10 +507,10 @@
     </profile>
     <interfaces>
         <interface name="management">
-            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+            <inet-address value="${jboss.bind.address.management:0.0.0.0}"/>
         </interface>
         <interface name="public">
-            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+            <inet-address value="${jboss.bind.address:0.0.0.0}"/>
         </interface>
     </interfaces>
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">


### PR DESCRIPTION
The container was initially configured to accept connections only from `127.0.0.1`. When forwarding the appropriate port for the container, we could hit the metrics endpoint, but a pod running within the cluster wouldn't be able to scrape that endpoint.

* updated bind addresses to `0.0.0.0`