### PR TITLE
Add Prometheus exporter to Cassandra chart

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.2
+version: 0.0.3

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -1,4 +1,124 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-script
+data:
+  config.yaml: |
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi
+    lowercaseOutputLabelNames: true
+    lowercaseOutputName: true
+    # whitelistObjectNames: ["org.apache.cassandra.metrics:*,org.apache.cassandra:*,java.lang:*"]
+    rules:
+    # Generic gauges with 0-2 labels
+    - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(\S*)><>Value
+      name: cassandra_$1_$5
+      type: GAUGE
+      labels:
+        "$1": "$4"
+        "$2": "$3"
+
+    # Generic JVM metrics
+    - pattern: 'java.lang<type=Memory><(\w+)MemoryUsage>(\w+): (\d+)'
+      name: jvm_memory_usage_$2_bytes
+      labels:
+        area: "$1"  # Heap/NonHeap
+      value: $3
+      type: GAUGE
+
+    - pattern: 'java.lang<type=OperatingSystem><>ProcessCpuLoad: (.[0-9]*[.]?[0-9]+)'
+      name: jvm_process_cpu_load
+      value: $1
+      type: GAUGE
+
+    - pattern: 'java.lang<type=OperatingSystem><>TotalPhysicalMemorySize: (\d+)'
+      name: jvm_physical_memory_size
+      value: $1
+      type: GAUGE
+
+    # name is always the same, the name of the GC
+    - pattern: 'java.lang<type=GarbageCollector, name=[^,]+, key=([^>]+)><LastGcInfo, memoryUsageAfterGc>(used|commited): (\d+)'
+      name: jvm_memory_after_gc_$2_bytes
+      value: $3
+      labels:
+        space: $1
+      type: GAUGE
+
+    - pattern: 'java.lang<type=GarbageCollector, name=[^>]+><LastGcInfo>duration: (\d+)'
+      name: jvm_gc_duration_seconds
+      value: $1
+      type: GAUGE
+      # Convert microseconds to seconds
+      valueFactor: 0.000001
+
+    # java.lang<type=GarbageCollector, name=G1 Young Generation><>CollectionCount
+    - pattern: 'java.lang<type=GarbageCollector, name=([^>]+)><>CollectionCount: (\d+)'
+      name: jvm_gc_collection_count
+      value: $2
+      labels:
+        name: $1
+      type: GAUGE
+
+    #
+    # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+    # TotalLatency is the sum of all latencies since server start
+    #
+    - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)?(?:Total)(Latency)><>Count
+      name: cassandra_$1_$5$6_seconds_sum
+      type: UNTYPED
+      labels:
+        "$1": "$4"
+        "$2": "$3"
+      # Convert microseconds to seconds
+      valueFactor: 0.000001
+
+    - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=((?:.+)?(?:Latency))><>Count
+      name: cassandra_$1_$5_seconds_count
+      type: UNTYPED
+      labels:
+        "$1": "$4"
+        "$2": "$3"
+
+    - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)><>Count
+      name: cassandra_$1_$5_count
+      type: UNTYPED
+      labels:
+        "$1": "$4"
+        "$2": "$3"
+
+    - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=((?:.+)?(?:Latency))><>(\d+)thPercentile
+      name: cassandra_$1_$5_seconds
+      type: GAUGE
+      labels:
+        "$1": "$4"
+        "$2": "$3"
+        quantile: "0.$6"
+      # Convert microseconds to seconds
+      valueFactor: 0.000001
+
+    - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)><>(\d+)thPercentile
+      name: cassandra_$1_$5
+      type: GAUGE
+      labels:
+        "$1": "$4"
+        "$2": "$3"
+        quantile: "0.$6"
+
+    # Get mean write and read latency
+    - pattern: org.apache.cassandra.metrics<type=Keyspace(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=((?:.+)?(?:)(?:Read|Write)Latency)><>Mean
+      name: cassandra_keyspace_$4_seconds_average
+      type: GAUGE
+      labels: 
+        "$1": "$2"
+      # Convert microseconds to seconds
+      valueFactor: 0.000001
+
+
+    - pattern: 'org.apache.cassandra.net<type=FailureDetector><>(\w+)EndpointCount: (\d+)'
+      name: cassandra_$1_endpoint_count
+      value: $2
+      type: GAUGE
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: cassandra
@@ -56,11 +176,24 @@ spec:
           requests:
             cpu: "500m"
             memory: 2G
-      - name: exporter
-        image: criteord/cassandra_exporter:2.3.8
-        env:
-          - name: CASSANDRA_EXPORTER_CONFIG_host
-            value: localhost:7199
-        ports:
-        - containerPort: 8080
-          name: exporter
+      - name: jmx-exporter
+        image: bitnami/jmx-exporter:0.17.2
+        command:
+          - java
+          - -jar
+          - jmx_prometheus_httpserver.jar
+        args:
+          - "9000"
+          - config.yaml
+        volumeMounts:
+        - mountPath: /opt/bitnami/jmx-exporter/config.yaml
+          subPath: config.yaml
+          name: config-script
+      volumes:
+      - name: config-script
+        configMap:
+          name: config-script
+          defaultMode: 0644
+          items:
+          - key: config.yaml
+            path: config.yaml

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -36,11 +36,31 @@ spec:
         env:
           - name: CASSANDRA_SEEDS
             value: "cassandra-0.cassandra.default.svc.cluster.local"
+          - name: CASSANDRA_DC
+            value: "TEST_DC"
+          - name: CASSANDRA_CLUSTER_NAME
+            value: "test-cluster"
           - name: JVM_OPTS
-            value: "-Xms1024M -Xmx1024M -XX:MaxPermSize=1024M -XX:MaxHeapSize=1024M"
+            value: "-Xms1024M -Xmx2048M -XX:MaxPermSize=1024M -XX:MaxHeapSize=2048M"
+          - name: MAX_HEAP_SIZE
+            value: 2048M
+          - name: HEAP_NEWSIZE
+            value: 512M
+          - name: CASSANDRA_LISTEN_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         resources:
           limits:
             memory: 2G
           requests:
             cpu: "500m"
             memory: 2G
+      - name: exporter
+        image: criteord/cassandra_exporter:2.3.8
+        env:
+          - name: CASSANDRA_EXPORTER_CONFIG_host
+            value: localhost:7199
+        ports:
+        - containerPort: 8080
+          name: exporter


### PR DESCRIPTION
* Added an available [prometheus exporter](https://github.com/criteo/cassandra_exporter) to the deployment
* set `CASSANDRA_DC`
* set `CASSANDRA_CLUSTER_NAME`
* updated `JVM_OPTS`
* set `MAX_HEAP_SIZE`
* set `HEAP_NEWSIZE`
* set `CASSANDRA_LISTEN_ADDRESS`