### PR TITLE
Chart Update: Cassandra

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.4
+version: 0.0.5

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -176,14 +176,15 @@ spec:
             - /bin/bash
             - -c
             - /ready-probe.sh
-          initialDelaySeconds: 45
-          timeoutSeconds: 15
+          initialDelaySeconds: 60
+          timeoutSeconds: 30
+          failureThreshold: 5
         resources:
           limits:
-            memory: 2G
+            memory: 3G
           requests:
             cpu: "500m"
-            memory: 2G
+            memory: 3G
       - name: jmx-exporter
         image: bitnami/jmx-exporter:0.17.2
         ports:

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -170,6 +170,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /ready-probe.sh
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
         resources:
           limits:
             memory: 2G

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -176,8 +176,8 @@ spec:
             - /bin/bash
             - -c
             - /ready-probe.sh
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
+          initialDelaySeconds: 45
+          timeoutSeconds: 15
         resources:
           limits:
             memory: 2G

--- a/charts/cassandra/values.yaml
+++ b/charts/cassandra/values.yaml
@@ -1,1 +1,1 @@
-image: bmedora/cassandra:4.1.0-jmx-readyprobe-v2
+image: ghcr.io/observiq/cassandra:1ba3b90

--- a/charts/cassandra/values.yaml
+++ b/charts/cassandra/values.yaml
@@ -1,1 +1,1 @@
-image: ghcr.io/observiq/cassandra:e6af083
+image: bmedora/cassandra:4.1.0-jmx-readyprobe-v2


### PR DESCRIPTION
* added readiness probe
* added script for readiness probe from [example](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/#using-a-statefulset-to-create-a-cassandra-ring)
* bumped chart version to `0.0.5`