### PR TITLE
Add loadgen and make cassandra -> apache cassandra

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.7
+version: 0.0.8

--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - forum
 maintainers:
   - name: observIQ
-name: cassandra
+name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
 version: 0.0.7

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -236,5 +236,6 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/cassandra/tools/bin/cassandra-stress mixed n=10000 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042'
+            # ignore errors as to skip read validations when running on mixed mode
+            - /opt/cassandra/tools/bin/cassandra-stress mixed n=10000 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042 -errors ignore'
           restartPolicy: Never

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -233,7 +233,7 @@ spec:
         spec:
           containers:
           - name: apache-cassandra-loadgen
-            image: ghcr.io/observiq/cassandra:cac2e00
+            image: {{ .Values.image }}
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -220,17 +220,19 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cassandra-loadgen
+  name: apache-cassandra-loadgen
   namespace: sample-apps
 spec:
   schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       parallelism: 1
       template:
         spec:
           containers:
-          - name: cassandra-loadgen
+          - name: apache-cassandra-loadgen
             image: ghcr.io/observiq/cassandra:cac2e00
             imagePullPolicy: IfNotPresent
             command:

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -121,41 +121,45 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cassandra
+  name: apache-cassandra
 spec:
   selector:
-    app.kubernetes.io/app: cassandra
+    app.kubernetes.io/app: apache-cassandra
   ports:
     - name: jmx
       protocol: TCP
       port: 7199
       targetPort: 7199
-    - name: cassandra
+    - name: apache-cassandra
       protocol: TCP
       port: 7000
       targetPort: 7000
+    - name: client
+      protocol: TCP
+      port: 9042
+      targetPort: 9042
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: cassandra
+  name: apache-cassandra
 spec:
-  serviceName: cassandra
+  serviceName: apache-cassandra
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/app: cassandra
+      app.kubernetes.io/app: apache-cassandra
   template:
     metadata:
       labels:
-        app.kubernetes.io/app: cassandra
+        app.kubernetes.io/app: apache-cassandra
     spec:
       containers:
-      - name: cassandra
+      - name: apache-cassandra
         image: {{ .Values.image }}
         env:
           - name: CASSANDRA_SEEDS
-            value: "cassandra-0.cassandra.sample-apps.svc.cluster.local"
+            value: "apache-cassandra-0.apache-cassandra.sample-apps.svc.cluster.local"
           - name: CASSANDRA_DC
             value: "TEST_DC"
           - name: CASSANDRA_CLUSTER_NAME
@@ -170,6 +174,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        ports:
+        - name: client
+          containerPort: 9042
         readinessProbe:
           exec:
             command:
@@ -181,10 +188,10 @@ spec:
           failureThreshold: 5
         resources:
           limits:
-            memory: 3G
+            memory: 2.5G
           requests:
             cpu: "500m"
-            memory: 3G
+            memory: 2.5G
       - name: jmx-exporter
         image: bitnami/jmx-exporter:0.17.2
         ports:
@@ -209,3 +216,25 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cassandra-loadgen
+  namespace: sample-apps
+spec:
+  schedule: "*/2 * * * *"
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: cassandra-loadgen
+            image: ghcr.io/observiq/cassandra:cac2e00
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - /opt/cassandra/tools/bin/cassandra-stress mixed n=10000 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042'
+          restartPolicy: Never

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -223,7 +223,7 @@ metadata:
   name: cassandra-loadgen
   namespace: sample-apps
 spec:
-  schedule: "*/2 * * * *"
+  schedule: "*/5 * * * *"
   jobTemplate:
     spec:
       parallelism: 1

--- a/charts/cassandra/values.yaml
+++ b/charts/cassandra/values.yaml
@@ -1,2 +1,2 @@
-image: ghcr.io/observiq/cassandra:1ba3b90
+image: ghcr.io/observiq/cassandra:cac2e00
 replicas: 3


### PR DESCRIPTION
These were asks of Grafana, porting them here so that in future vendors of the chart the changes will not get lost.

[cassandra-stress](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwilso36lev9AhWxFlkFHTcRAroQFnoECA8QAQ&url=https%3A%2F%2Fcassandra.apache.org%2Fdoc%2Flatest%2Fcassandra%2Ftools%2Fcassandra_stress.html&usg=AOvVaw0ySe67fpnNvnmTB-k6wm2i) is the tool being used here and requires connection with port 9042. We target the service endpoint in order to let that do the load balancing.

The cronjob will run periodically in 5 minute stints we are both reading and writing data to the pods. 


![image](https://user-images.githubusercontent.com/32067685/226437827-bae04789-4d52-4949-8c51-5b2754f38dd7.png)


As far as renames I think container should be the only thing left named `cassandra` but we wanted to make sure to use `apache-cassandra` whenever possible.