### PR TITLE
Lower cassandra-stress loadgen to be 100

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.8
+version: 0.0.9

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -239,5 +239,5 @@ spec:
             - /bin/sh
             - -c
             # ignore errors as to skip read validations when running on mixed mode
-            - /opt/cassandra/tools/bin/cassandra-stress mixed n=10000 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042 -errors ignore'
+            - /opt/cassandra/tools/bin/cassandra-stress mixed n=100 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore
           restartPolicy: Never


### PR DESCRIPTION
Some users who don't have enough resources to consistently run with 100000 iterations cause the cronjob to always fail. Generically we just want to generate some reads/writes so we think lowering this to 100 makes sense. 

```
Failed to create client too many times
Failed to create client too many times
Failed to create client too many times
Failed to create client too many times
java.lang.RuntimeException: Failed to execute warmup
	at org.apache.cassandra.stress.StressAction.warmup(StressAction.java:128)
	at org.apache.cassandra.stress.StressAction.run(StressAction.java:71)
	at org.apache.cassandra.stress.Stress.run(Stress.java:101)
	at org.apache.cassandra.stress.Stress.main(Stress.java:54)
command terminated with exit code 1
```