### PR TITLE
Removed squid from container workflow

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -20,7 +20,6 @@ jobs:
           - "tensorflowload"
           - "wildfly"
           - "cassandra"
-          - "squid"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Initially forgot to update the container workflow to not include Squid, as the custom container is not currently needed.