### PR TITLE
Added matrix for architectures to CI

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -21,6 +21,12 @@ jobs:
           - "wildfly"
           - "cassandra"
           - "apache-mesos"
+        architecture:
+          - "arm64"
+          - "amd64"
+        exclude:
+          - app: "apache-mesos"
+            architecture: "amd64"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -50,6 +56,6 @@ jobs:
         with:
           context: container/${{ matrix.app }}
           file: container/${{ matrix.app }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.architecture }}
           push:  true
           tags:  ghcr.io/observiq/${{ matrix.app }}:${{ steps.get-tag.outputs.tag }}


### PR DESCRIPTION
This should allow us to use the single "build and push" job and exclude combinations we don't want built/pushed for containers we create.

* Updated container CI to use a matrix for different architectures 
  * excluded the combination of mesos and amd64