### PR TITLE
Squid chart update

### DIFF
--- a/charts/squid/Chart.yaml
+++ b/charts/squid/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: squid
 sources:
   - https://github.com/squid-cache/squid
-version: 0.0.1
+version: 0.0.2

--- a/charts/squid/templates/squid-configmap.yaml
+++ b/charts/squid/templates/squid-configmap.yaml
@@ -12,6 +12,7 @@ data:
     acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
     acl localnet src fc00::/7       	# RFC 4193 local private network range
     acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+    acl all src 0.0.0.0/0
     acl SSL_ports port 443
     acl Safe_ports port 80		# http
     acl Safe_ports port 21		# ftp
@@ -30,7 +31,7 @@ data:
     http_access deny manager
     http_access allow localhost
     http_access allow localnet
-    http_access deny all
+    http_access allow all
     http_port 3128
     coredump_dir /var/spool/squid
     refresh_pattern ^ftp:		1440	20%	10080

--- a/charts/squid/templates/squid-deployment.yaml
+++ b/charts/squid/templates/squid-deployment.yaml
@@ -39,20 +39,6 @@ spec:
         - name: squid-config-volume
           mountPath: /etc/squid/squid.conf
           subPath: squid.conf
-      - name: exporter
-        image: {{ .Values.exporterImage }}
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: SQUID_HOSTNAME
-          value: localhost
-        - name: SQUID_EXPORTER_LISTEN
-          value: ":9301"
-        - name: SQUID_PORT
-          value: "3128"
-        ports:
-        - name: metrics
-          containerPort: 9301
-          protocol: TCP
       volumes:
         - name: squid-config-volume
           configMap:

--- a/charts/squid/values.yaml
+++ b/charts/squid/values.yaml
@@ -1,2 +1,1 @@
 squidImage: ubuntu/squid:edge
-exporterImage: boynux/squid-exporter:v1.9


### PR DESCRIPTION
[bumped chart version](https://github.com/observIQ/charts/commit/d4128a3cf6ee563d21d77993937cb93919738d66)

[updated squid configuration to allow http requests from anywhere](https://github.com/observIQ/charts/commit/72a6ab387a17aad73e996697403140a42549775b)
 
[removed the exporter from the deployment'](https://github.com/observIQ/charts/commit/b197eda012e7401e9b29b2e8ce2d95b32261c32f)
 
[removed exporter image](https://github.com/observIQ/charts/commit/f288c0df5b44d93289a7d04e1500b49a347b2a50)