### PR TITLE
Removing exclusion for building Mesos (amd64)

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -24,9 +24,6 @@ jobs:
         architecture:
           - "arm64"
           - "amd64"
-        exclude:
-          - app: "apache-mesos"
-            architecture: "amd64"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
There are issues w/ pulling the image being built for `arm64` when it's built here, but when it was built on my machine and pushed to `bmedora/apache-mesos-1.11:0.0.3` that was able to be pulled down, regardless of the architecture.