### PR TITLE
Updated Mesos configmap and image

### DIFF
--- a/charts/apache-mesos/Chart.yaml
+++ b/charts/apache-mesos/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: mesos
 sources:
   - https://mesos.apache.org/
-version: 0.0.3
+version: 0.0.4

--- a/charts/apache-mesos/templates/configmap.yaml
+++ b/charts/apache-mesos/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
 
     # Run mesos master, agent, and exporter in the background
     mesos-master --work_dir=/var/lib/mesos --log_dir=/var/log/mesos/ &
-    mesos-agent --work_dir=/var/lib/mesos/agent --master=localhost:5050 --launcher=posix --systemd_enable_support=false &
+    mesos-agent --work_dir=/var/lib/mesos/agent --log_dir=/var/log/mesos --master=localhost:5050 --launcher=posix --systemd_enable_support=false &
     /mesos_exporter-1.1.2.linux-arm64/mesos_exporter -master http://localhost:5050 &
 
     # Infinite loop to keep container alive

--- a/charts/apache-mesos/values.yaml
+++ b/charts/apache-mesos/values.yaml
@@ -1,1 +1,1 @@
-image: ghcr.io/observiq/apache-mesos:c292be1
+image: ghcr.io/observiq/apache-mesos:84faf23


### PR DESCRIPTION
[updated the startup script to include logs from the mesos agent](https://github.com/observIQ/charts/commit/fa445f04142932faf2b0c0f6cef97abb9c7f6ce0)
 
[bumped chart version](https://github.com/observIQ/charts/commit/a6fa57191fd0197475c7147476ef740245d3fd7b)
 
[updated the values yaml to use new image](https://github.com/observIQ/charts/commit/f2614035a1ca1e019e5d62cb679a0fd025b45fbe)

* New image supports both arm64/amd64
