### PR TITLE
Container workflow fix

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -21,9 +21,6 @@ jobs:
           - "wildfly"
           - "cassandra"
           - "apache-mesos"
-        architecture:
-          - "linux/arm64"
-          - "linux/amd64"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,6 +50,6 @@ jobs:
         with:
           context: container/${{ matrix.app }}
           file: container/${{ matrix.app }}/Dockerfile
-          platforms: ${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
           push:  true
           tags:  ghcr.io/observiq/${{ matrix.app }}:${{ steps.get-tag.outputs.tag }}


### PR DESCRIPTION
* reverted container workflow to where a single job is run per application

This should resolve the issue we are having where, while containers will build successfully, the separate architectures being built on separate jobs would get tagged differently, which is not what we want.