### PR TITLE
Updated image being used in Mesos chart

### DIFF
--- a/charts/apache-mesos/Chart.yaml
+++ b/charts/apache-mesos/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: mesos
 sources:
   - https://mesos.apache.org/
-version: 0.0.4
+version: 0.0.5

--- a/charts/apache-mesos/values.yaml
+++ b/charts/apache-mesos/values.yaml
@@ -1,1 +1,1 @@
-image: ghcr.io/observiq/apache-mesos:84faf23
+image: ghcr.io/observiq/apache-mesos:1604ee3


### PR DESCRIPTION
* updated mesos values to point to correct image
* bumped chart version

With the change/fix for CI, the only charts that need to be updated are the ones that were pointed to the broken/messed up container release.