### PR TITLE
Fix chart release workflow

### DIFF
--- a/charts/couchbase-community/Chart.yaml
+++ b/charts/couchbase-community/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: couchbase
 sources:
   - https://www.couchbase.com/
-version: 0.0.1
+version: 0.0.2

--- a/charts/couchbase-community/README.md
+++ b/charts/couchbase-community/README.md
@@ -2,16 +2,9 @@
 
 This chart deploys a StatefulSet with 3 replicas that are running Couchbase Community Edition.
 
-
-## Configuring the nodes
-
-These nodes are unconfigured by default. To fix this, do the following:
-1. Forward the port for the container, to access the UI with your local browser
-2. Follow [these instructions](https://hub.docker.com/_/couchbase) to configure each node.
+> NOTE: To run this, we recommend starting Docker/k8s with 4 cores and 8 gigabytes.
 
 ## Creating a cluster
-
-After configuring each of the nodes, do the following:
 
 1. Forward port `8091` on the first pod in the statefulset by running the following command:
 ```


### PR DESCRIPTION
> Note: Also updated some documentation, I think it makes sense to include these changes here to avoid another version bump

**Changes**
* [bumping chart version to fix releases](https://github.com/observIQ/charts/pull/47/commits/e2fce6295b33383244e10c36e6088a30f25196a0)
* [removed container configuration instructions, added note on resources](https://github.com/observIQ/charts/pull/47/commits/859ba9e2f717c8c67083dfe77e33cd53aa2b2b1e)

**Details**

In [this PR](https://github.com/observIQ/charts/pull/45) for updating Couchbase instructions in a README, we opted to not bump the chart version, as we thought it wouldn't matter for this case. We expected the release action to fail there, I believe. 

However, in a [future PR release action](https://github.com/observIQ/charts/actions/runs/5334677717) we see that fail with the same error in the first failed release

Error:
```
Error: error creating GitHub release couchbase-0.0.1: POST https://api.github.com/repos/observIQ/charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```