### PR TITLE
Added ports to Hadoop services

### DIFF
--- a/charts/apache-hadoop/Chart.yaml
+++ b/charts/apache-hadoop/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: hadoop
 sources:
   - https://hadoop.apache.org/
-version: 0.0.1
+version: 0.0.2

--- a/charts/apache-hadoop/templates/hdfs-dn-svc.yaml
+++ b/charts/apache-hadoop/templates/hdfs-dn-svc.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: hdfs-dn
 spec:
   ports:
+  - name: exporter
+    port: 12345
+    protocol: TCP
   - name: dfs
     port: 9000
     protocol: TCP

--- a/charts/apache-hadoop/templates/hdfs-nn-svc.yaml
+++ b/charts/apache-hadoop/templates/hdfs-nn-svc.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: hdfs-nn
 spec:
   ports:
+  - name: exporter
+    port: 12345
+    protocol: TCP
   - name: dfs
     port: 9000
     protocol: TCP

--- a/charts/apache-hadoop/templates/yarn-nm-svc.yaml
+++ b/charts/apache-hadoop/templates/yarn-nm-svc.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: yarn-nm
 spec:
   ports:
+  - name: exporter
+    port: 12345
+    protocol: TCP
   - port: 8088
     name: web
   - port: 8082

--- a/charts/apache-hadoop/templates/yarn-rm-svc.yaml
+++ b/charts/apache-hadoop/templates/yarn-rm-svc.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: yarn-rm
 spec:
   ports:
+  - name: exporter
+    port: 12345
+    protocol: TCP
   - port: 8088
     name: web
   clusterIP: None


### PR DESCRIPTION
**Changes**
* [Updated each service to include the port for the exporter that was added](https://github.com/observIQ/charts/commit/dfb9fd342c6197050fdb91e5f629ef925d50b1df)
* [bumped chart version](https://github.com/observIQ/charts/pull/48/commits/b9dfbfb5a28ecc2f76c83f820ebc992bd80449f2)

**Details**

We have to add the exporter port to the service so that we can run this within the `k3d` environment as a sample application. We have to be able to have the `scrape_config` for this target the exporters that exist.
