### PR TITLE
Add chart and container for Varnish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
           - "apache-mesos"
           - "couchbase-community"
           - "apache-hadoop"
+          - "varnish"
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -22,6 +22,7 @@ jobs:
           - "cassandra"
           - "apache-mesos"
           - "couchbase-community"
+          - "varnish"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+appVersion: 4.1.0
+engine: gotpl
+home: https://github.com/observIQ/charts/tree/main/charts/cassandra
+keywords:
+  - community
+  - forum
+maintainers:
+  - name: observIQ
+name: apache-cassandra
+sources:
+  - https://github.com/apache/cassandra
+version: 0.0.9

--- a/charts/varnish/templates/deployment.yaml
+++ b/charts/varnish/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: varnish-config
+data:
+  # Use a real secret in production, not a configmap.
+  secret: |
+    replace-with-real-secret
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: varnish
+  namespace: default
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: varnish
+  template:
+    metadata:
+      name: varnish
+      labels:
+        app: varnish
+    spec:
+      # Process namespace sharing is required for the varnish and exporter containers
+      # to share the Varnish working directory.
+      shareProcessNamespace: true
+      containers:
+      - name: varnish
+        env:
+          - name: VARNISH_HTTP_PORT
+            value: "8080"
+        image: varnish:stable
+        volumeMounts:
+          - name: varnish-config
+            mountPath: /etc/varnish/secret
+            subPath: secret
+          - name: shared-data
+            mountPath: /var/lib/varnish
+      - name: exporter
+        command:
+          - "/prometheus_varnish_exporter"
+        image: bmedora/varnish-exporter:stable
+        volumeMounts:
+          - name: shared-data
+            mountPath: /var/lib/varnish
+            readOnly: true
+        ports:
+        - containerPort: 9131
+          name: prometheus
+      volumes:
+        - name: varnish-config
+          configMap:
+            name: varnish-config
+        - name: shared-data
+          emptyDir: {}

--- a/charts/varnish/values.yaml
+++ b/charts/varnish/values.yaml
@@ -1,0 +1,1 @@
+replicas: 3

--- a/container/varnish-exporter/Dockerfile
+++ b/container/varnish-exporter/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stable-slim as stage
+
+WORKDIR /exporter
+ADD https://github.com/jonnenauha/prometheus_varnish_exporter/releases/download/1.6.1/prometheus_varnish_exporter-1.6.1.linux-amd64.tar.gz /exporter/exporter.tar.gz
+RUN tar -xvf exporter.tar.gz
+RUN chmod +x /exporter/prometheus_varnish_exporter-1.6.1.linux-amd64/prometheus_varnish_exporter
+
+FROM varnish:stable
+
+COPY --from=stage /exporter/prometheus_varnish_exporter-1.6.1.linux-amd64/prometheus_varnish_exporter /prometheus_varnish_exporter
+ENTRYPOINT [ "/prometheus_varnish_exporter" ]


### PR DESCRIPTION
**Changes**
[added Dockerfile to build varnish exporter for 6.0.11 because it is stable](https://github.com/observIQ/charts/commit/9a5d822ce66be0866c435b8faca1db67162dcd74) 

[added chart to deploy varnish and an exporter](https://github.com/observIQ/charts/commit/fd10ece808e0644b2c76811eacb6a52869eeebb3)