### PR TITLE
Fixed typo in the container CI workflow for Varnish

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -22,7 +22,7 @@ jobs:
           - "cassandra"
           - "apache-mesos"
           - "couchbase-community"
-          - "varnish"
+          - "varnish-exporter"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
-appVersion: 4.1.0
+appVersion: 6.0.11
 engine: gotpl
-home: https://github.com/observIQ/charts/tree/main/charts/cassandra
+home: https://github.com/observIQ/charts/tree/main/charts/varnish
 keywords:
   - community
   - forum
 maintainers:
   - name: observIQ
-name: apache-cassandra
+name: varnish
 sources:
-  - https://github.com/apache/cassandra
-version: 0.0.9
+  - https://varnish-cache.org/
+version: 0.0.1


### PR DESCRIPTION
**Changes**

* [fixed typo for varnish in the app matrix](https://github.com/observIQ/charts/commit/6b36a565d40e0a2f702c4bc551cc3a80ac330a21)
* [updated the Chart.yaml file](https://github.com/observIQ/charts/pull/50/commits/62d5bbd2e328d312f9523ae56ee6fa6ae5f7e78e)

**Details**

These changes should resolve issues with the Github workflows that failed to run.