### PR TITLE
Updated Varnish `values.yaml` to include images.

### DIFF
--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.1
+version: 0.0.2

--- a/charts/varnish/templates/deployment.yaml
+++ b/charts/varnish/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         env:
           - name: VARNISH_HTTP_PORT
             value: "8080"
-        image: varnish:stable
+        image: {{ .Values.varnishImage }}
         volumeMounts:
           - name: varnish-config
             mountPath: /etc/varnish/secret
@@ -41,7 +41,7 @@ spec:
       - name: exporter
         command:
           - "/prometheus_varnish_exporter"
-        image: bmedora/varnish-exporter:stable
+        image: {{ .Values.exporterImage }}
         volumeMounts:
           - name: shared-data
             mountPath: /var/lib/varnish

--- a/charts/varnish/values.yaml
+++ b/charts/varnish/values.yaml
@@ -1,1 +1,3 @@
-replicas: 3
+replicas: 1
+varnishImage: varnish:stable
+exporterImage: ghcr.io/observiq/varnish-exporter:9b20a5f@sha256:345b08ba5bd12e196413263542dfe3738d837c8901b0e77739f929f110fbd651


### PR DESCRIPTION
**Changes**
* [updated images to be pulled from values.yaml file, specified the amd6…](https://github.com/observIQ/charts/commit/7c5821967e9dfcfda5dc3ac85bb1e300a0df30ca) 
* [bumped chart version](https://github.com/observIQ/charts/commit/185ef41c58a6037b10924cbd84477a40acb75fb6)

**Details**

Updates the chart to utilize the `values.yaml` file for specifying the number of replicas and images to be used for the app/exporter. Defaulted the exporter image to be the `amd64` container.