### PR TITLE
Added service to Varnish chart

### DIFF
--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.2
+version: 0.0.3

--- a/charts/varnish/templates/service.yaml
+++ b/charts/varnish/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: varnish-service
+  labels:
+    app: varnish
+spec:
+  ports:
+  - port: 9131
+    name: varnish-exporter
+  selector:
+    app: varnish


### PR DESCRIPTION
**Changes**
* [added service to target the exporter pod](https://github.com/observIQ/charts/commit/84bdb59094de6fee69e2d245258a0ca579a4dd48)
* [bumped chart version](https://github.com/observIQ/charts/pull/52/commits/5ed61469e4ddc8e2c1333ca8d95e9338c6fa5a01)

**Details**

This will allow us to specifically target the exporter that's running in the deployment to scrape metrics and pull them into the local `k3d` environment.