### PR TITLE
Updated Varnish deployment metadata

### DIFF
--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.3
+version: 0.0.4

--- a/charts/varnish/templates/deployment.yaml
+++ b/charts/varnish/templates/deployment.yaml
@@ -11,7 +11,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: varnish
-  namespace: default
 spec:
   replicas: {{ .Values.replicas }}
   selector:


### PR DESCRIPTION
**Changes**
* [removed specifying which namespace the deployment is deployed to](https://github.com/observIQ/charts/commit/f52a9b29d0a3038403ee476757089e0c95ebc809)
* [bumped chart version](https://github.com/observIQ/charts/commit/c4afa038196246cb1a0b4b038da30298b75be9f1)

**Details**

Have to remove where we specify what namespace the deployment is applied to so that the sample application in `k3d` gets deployed properly.