### PR TITLE
Add NGINX as Varnish backend

### DIFF
--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.4
+version: 0.0.5

--- a/charts/varnish/templates/configmaps.yaml
+++ b/charts/varnish/templates/configmaps.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  default.conf: |
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+        location /status {
+            stub_status on;
+            access_log  on;           
+            allow all;
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: varnish-secret
+data:
+  # Use a real secret in production, not a configmap.
+  secret: |
+    replace-with-real-secret
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: varnish-config
+data:
+  default.vcl: |
+    vcl 4.1;
+    backend server_nginx_0 {
+        .host = "localhost";
+        .port = "8080";
+    }
+---

--- a/charts/varnish/templates/deployment.yaml
+++ b/charts/varnish/templates/deployment.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: varnish-config
-data:
-  # Use a real secret in production, not a configmap.
-  secret: |
-    replace-with-real-secret
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,17 +17,23 @@ spec:
       # to share the Varnish working directory.
       shareProcessNamespace: true
       containers:
+      - name: nginx
+        image: {{ .Values.nginxImage }}
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
       - name: varnish
-        env:
-          - name: VARNISH_HTTP_PORT
-            value: "8080"
         image: {{ .Values.varnishImage }}
         volumeMounts:
-          - name: varnish-config
+          - name: varnish-secret
             mountPath: /etc/varnish/secret
             subPath: secret
           - name: shared-data
             mountPath: /var/lib/varnish
+          - name: varnish-config
+            mountPath: /etc/varnish/default.vcl
+            subPath: default.vcl
       - name: exporter
         command:
           - "/prometheus_varnish_exporter"
@@ -49,8 +46,14 @@ spec:
         - containerPort: 9131
           name: prometheus
       volumes:
+        - name: varnish-secret
+          configMap:
+            name: varnish-secret
         - name: varnish-config
           configMap:
             name: varnish-config
+        - name: nginx-config
+          configMap:
+            name: nginx-config
         - name: shared-data
           emptyDir: {}

--- a/charts/varnish/values.yaml
+++ b/charts/varnish/values.yaml
@@ -1,3 +1,4 @@
 replicas: 1
 varnishImage: varnish:stable
 exporterImage: ghcr.io/observiq/varnish-exporter:9b20a5f@sha256:345b08ba5bd12e196413263542dfe3738d837c8901b0e77739f929f110fbd651
+nginxImage: nginx:1.25.1


### PR DESCRIPTION
**Changes**
* [moved configmaps to separate file](https://github.com/observIQ/charts/commit/68b804779410c354bcf2a558964e462779c159c4)
* [added nginx to the varnish deployment](https://github.com/observIQ/charts/commit/b88215a9c9130483609bf5f6f6f5dd32f306a173)
* [bumped chart version, added nginxImage to values yaml](https://github.com/observIQ/charts/commit/81776349c3ac65a66c63cb0272df6b8a10e4b67d)

**Details**
These changes add NGINX as a backend for Varnish and is intended to allow generating load against the environment.