### PR TITLE
Added health probe to Varnish deployment

### DIFF
--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.5
+version: 0.0.6

--- a/charts/varnish/templates/configmaps.yaml
+++ b/charts/varnish/templates/configmaps.yaml
@@ -41,8 +41,18 @@ metadata:
 data:
   default.vcl: |
     vcl 4.1;
+
+    probe health {
+        .url = "/";
+        .timeout = 2s;
+        .interval = 5s;
+        .window = 5;
+        .threshold = 3;
+    } 
+
     backend server_nginx_0 {
         .host = "localhost";
         .port = "8080";
+        .probe = health;
     }
 ---

--- a/charts/varnish/templates/service.yaml
+++ b/charts/varnish/templates/service.yaml
@@ -8,5 +8,7 @@ spec:
   ports:
   - port: 9131
     name: varnish-exporter
+  - port: 8080
+    name: nginx
   selector:
     app: varnish


### PR DESCRIPTION
## **Changes**
* [added nginx port to varnish service](https://github.com/observIQ/charts/commit/fa33206d9c7b1b4bfcaff7e007466ebcfc737318)
* [updated varnish config with health probe](https://github.com/observIQ/charts/commit/ec286c3447b0afdc22770d2b028c9b03d9c77897)
* [bumped chart version to 0.0.6](https://github.com/observIQ/charts/commit/a0fc7c82251ab9e00f67195570e9a45c7e9184b2)

## **Details**
These changes are to help with load generation against Varnish for the sample application. The port for NGINX has been added to the service, so that the load generator can send NGINX requests. 

The configuration for varnish has been updated, without a health probe, the backend metric for `varnish_backend_up` and `varnish_backend_happy` report zero values. The chart version has been bumped accordingly.