### PR TITLE
Updated Varnish service port

### DIFF
--- a/charts/varnish/templates/service.yaml
+++ b/charts/varnish/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   ports:
   - port: 9131
     name: varnish-exporter
-  - port: 8080
-    name: nginx
+  - port: 80
+    name: varnish-reverse-proxy
   selector:
     app: varnish


### PR DESCRIPTION
## Changes
* [updated service port to be 80 where varnish is listening](https://github.com/observIQ/charts/commit/c497d72fe10fc72f26f57bf029486ef491d402e1)

## Details
I mistakenly exposed NGINX directly through the service, rather than exposing Varnish and using it as a reverse proxy, as intended. This will resolve that issue.