### PR TITLE
Varnish Chart: Bump version to 0.0.7

### DIFF
--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.6
+version: 0.0.7


### PR DESCRIPTION
## Changes
* [updated varnish chart to 0.0.7](https://github.com/observIQ/charts/commit/65a8150c791a7aadb0d9f75f647e3ef892c1e4be)

## Details
I forgot to do this in the previous PR for varnish that we merged [here](https://github.com/observIQ/charts/pull/57).