### PR TITLE
Added Aerospike CE cluster chart

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+appVersion: 6.3.0.5
+engine: gotpl
+home: https://github.com/observIQ/charts/tree/main/charts/aerospike
+keywords:
+  - community
+  - forum
+maintainers:
+  - name: observIQ
+name: aerospike
+sources:
+  - https://aerospike.com/
+version: 0.0.1

--- a/charts/aerospike/templates/configmaps.yaml
+++ b/charts/aerospike/templates/configmaps.yaml
@@ -4,14 +4,6 @@ metadata:
   name: aerospike-config
 data:
   aerospike.conf: |
-    # Aerospike database configuration file
-    # This template sets up a single-node, single namespace developer environment.
-    #
-    # Alternatively, you can pass in your own configuration file.
-    # You can see more examples at
-    # https://github.com/aerospike/aerospike-server/tree/master/as/etc
-
-    # This stanza must come first.
     service {
 
     }
@@ -26,7 +18,7 @@ data:
     network {
             service {
                     address any
-                    access-address aerospike-0
+                    access-address aerospike-0.aerospike.default.svc.cluster.local
                     port 3000
             }
 

--- a/charts/aerospike/templates/configmaps.yaml
+++ b/charts/aerospike/templates/configmaps.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aerospike-config
+data:
+  aerospike.conf: |
+    # Aerospike database configuration file
+    # This template sets up a single-node, single namespace developer environment.
+    #
+    # Alternatively, you can pass in your own configuration file.
+    # You can see more examples at
+    # https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+    # This stanza must come first.
+    service {
+
+    }
+
+    logging {
+            # Send log messages to stdout
+            console {
+                    context any info
+            }
+    }
+
+    network {
+            service {
+                    address any
+                    access-address aerospike-0
+                    port 3000
+            }
+
+            heartbeat {
+                    mode mesh
+                    port 3002
+
+                    mesh-seed-address-port aerospike-0.aerospike.default.svc.cluster.local 3002
+                    mesh-seed-address-port aerospike-1.aerospike.default.svc.cluster.local 3002
+                    mesh-seed-address-port aerospike-2.aerospike.default.svc.cluster.local 3002
+
+                    interval 150
+                    timeout 10
+            }
+
+            fabric {
+                    port 3001
+            }
+
+    }
+
+    namespace test {
+            default-ttl 30d # use 0 to never expire/evict.
+            memory-size 1G
+            nsup-period 120
+            replication-factor 1
+            storage-engine device {
+                    data-in-memory false # if true, in-memory, persisted to the filesystem
+                    file /opt/aerospike/data/test.dat
+                    filesize 4G
+                    read-page-cache true
+            }
+    }

--- a/charts/aerospike/templates/loadgen.yaml
+++ b/charts/aerospike/templates/loadgen.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: aerospike-loadgen
+  namespace: default
+spec:
+  schedule: "*/2 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      parallelism: 1
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: asbench
+            image: bmedora/aerospike-benchmark:0.0.1
+            args:
+              - -h
+              - aerospike.default.svc.cluster.local
+              - -k
+              - "1000"
+              - -w
+              - RU,50
+          restartPolicy: Never

--- a/charts/aerospike/templates/service.yaml
+++ b/charts/aerospike/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aerospike
+  name: aerospike
+spec:
+  clusterIP: None
+  ports:
+  - port: 3000
+  selector:
+    app: aerospike

--- a/charts/aerospike/templates/service.yaml
+++ b/charts/aerospike/templates/service.yaml
@@ -8,5 +8,8 @@ spec:
   clusterIP: None
   ports:
   - port: 3000
+    name: aerospike
+  - port: 9145
+    name: prometheus
   selector:
     app: aerospike

--- a/charts/aerospike/templates/statefulset.yaml
+++ b/charts/aerospike/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app: aerospike
 spec:
   serviceName: aerospike
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: aerospike
@@ -18,14 +18,22 @@ spec:
       containers:
       - name: aerospike
         image: aerospike/aerospike-server:6.3.0.5
+        args:
+          - --config-file=/opt/aerospike/etc/aerospike.conf
         ports:
         - containerPort: 3000
+        - containerPort: 3001
+        - containerPort: 3002
         resources:
           limits:
             cpu: "500m"
             memory: 1Gi
+        volumeMounts:
+        - name: aerospike-config-volume
+          mountPath: /opt/aerospike/etc/aerospike.conf
+          subPath: aerospike.conf
       - name: aerospike-prometheus-exporter
-        image: aerospike/aerospike-prometheus-exporter:1.11.0
+        image: aerospike/aerospike-prometheus-exporter:1.12.0
         ports:
         - containerPort: 9145
           name: prometheus
@@ -34,3 +42,10 @@ spec:
             value: localhost
           - name: AS_PORT
             value: "3000"
+      volumes:
+        - name: aerospike-config-volume
+          configMap:
+            name: aerospike-config
+            items:
+            - key: aerospike.conf
+              path: aerospike.conf

--- a/charts/aerospike/templates/statefulset.yaml
+++ b/charts/aerospike/templates/statefulset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: aerospike
+  labels:
+    app: aerospike
+spec:
+  serviceName: aerospike
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aerospike
+  template:
+    metadata:
+      labels:
+        app: aerospike
+    spec:
+      containers:
+      - name: aerospike
+        image: aerospike/aerospike-server:6.3.0.5
+        ports:
+        - containerPort: 3000
+        resources:
+          limits:
+            cpu: "500m"
+            memory: 1Gi
+      - name: aerospike-prometheus-exporter
+        image: aerospike/aerospike-prometheus-exporter:1.11.0
+        ports:
+        - containerPort: 9145
+          name: prometheus
+        env:
+          - name: AS_HOST
+            value: localhost
+          - name: AS_PORT
+            value: "3000"

--- a/container/aerospike-benchmark/Dockerfile
+++ b/container/aerospike-benchmark/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.18
+
+# Build the Aerospike benchmark binary
+RUN apk add go git && \
+    git clone https://github.com/aerospike/aerospike-client-go.git && \
+    cd aerospike-client-go/tools/benchmark && \
+    go build . && \
+    mv benchmark /etc && \
+    rm -rf /aerospike-client-go && \
+    apk del go git
+
+ENTRYPOINT [ "/etc/benchmark" ]


### PR DESCRIPTION
## Changes
* [started aerospike helm chart](https://github.com/observIQ/charts/commit/48669e66ff98a06a412990ed3c58c365fac8753c)
* [added container with aerospike benchmark go binary installed](https://github.com/observIQ/charts/commit/479c028770ebc684a363e84de2bea1100a3b5034)
* [added aerospike.conf as configmap, added loadgen to aerospike chart](https://github.com/observIQ/charts/commit/b8a884c9ef818261c6cd418d118fdab9ac375a7a)

## Details
This chart deploys an Aerospike cluster with 3 nodes, version `6.3.0.5` of **Aerospike CE** with some load generation from an aerospike benchmark tool.