### PR TITLE
CI add Aerospike to container and chart releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
           - "couchbase-community"
           - "apache-hadoop"
           - "varnish"
+          - "aerospike"
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -23,6 +23,7 @@ jobs:
           - "apache-mesos"
           - "couchbase-community"
           - "varnish-exporter"
+          - "aerospike-benchmark"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/aerospike/templates/loadgen.yaml
+++ b/charts/aerospike/templates/loadgen.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
           - name: asbench
-            image: bmedora/aerospike-benchmark:0.0.1
+            image: {{ .Values.loadgenImage }}
             args:
               - -h
               - aerospike.default.svc.cluster.local

--- a/charts/aerospike/templates/statefulset.yaml
+++ b/charts/aerospike/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: aerospike
-        image: aerospike/aerospike-server:6.3.0.5
+        image: {{ .Values.aerospikeImage }}
         args:
           - --config-file=/opt/aerospike/etc/aerospike.conf
         ports:
@@ -33,7 +33,7 @@ spec:
           mountPath: /opt/aerospike/etc/aerospike.conf
           subPath: aerospike.conf
       - name: aerospike-prometheus-exporter
-        image: aerospike/aerospike-prometheus-exporter:1.12.0
+        image: {{ .Values.exporterImage }}
         ports:
         - containerPort: 9145
           name: prometheus

--- a/charts/aerospike/values.yaml
+++ b/charts/aerospike/values.yaml
@@ -1,0 +1,3 @@
+aerospikeImage: aerospike/aerospike-server:6.3.0.5
+exporterImage: aerospike/aerospike-prometheus-exporter:1.12.0
+loadgenImage: bmedora/aerospike-benchmark:0.0.1


### PR DESCRIPTION
## Changes
* [added aerospike container and chart to ci workflows](https://github.com/observIQ/charts/commit/63239851b7df5af261966210f50a91baf5374cde)
* [updated values yaml for aerospike](https://github.com/observIQ/charts/commit/a22b281bfc4f252b2bc0b0b254d2ab60f3530ed8)

## Details
Updated CI workflows to include the aerospike chart and container, updated the `values.yaml` to allow setting images for the aerospike server, the exporter, and the load generator containers.