### PR TITLE
Aerospike bump chart version to 0.0.2

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.1
+version: 0.0.2


### PR DESCRIPTION
## Changes
* [bumping chart version to 0.0.2](https://github.com/observIQ/charts/commit/d70fd83f5e4ce697a66e72dd713135a48073f337)

## Details
Forgot this step in this [PR](https://github.com/observIQ/charts/pull/60)