### PR TITLE
Update Aerospike load generator image

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.2
+version: 0.0.3

--- a/charts/aerospike/values.yaml
+++ b/charts/aerospike/values.yaml
@@ -1,3 +1,3 @@
 aerospikeImage: aerospike/aerospike-server:6.3.0.5
 exporterImage: aerospike/aerospike-prometheus-exporter:1.12.0
-loadgenImage: bmedora/aerospike-benchmark:0.0.1
+loadgenImage: ghcr.io/observiq/aerospike-benchmark:0095769


### PR DESCRIPTION
## Changes
* [updated benchmark image to point to the image built by ci](https://github.com/observIQ/charts/commit/02baa616bf5c469341eb2fe0fa1fdcffc678cd94)
* [bumped chart version to 0.0.3](https://github.com/observIQ/charts/commit/99dff9d1dc9b3607252980028bcf26779f9f60d8)

## Details
Updated the chart to point to the `aerospike-benchmark` image that's built with CI.