### PR TITLE
Cassandra: Update service

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.9
+version: 0.0.10

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -122,6 +122,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: apache-cassandra
+  labels:
+    app.kubernetes.io/service: apache-cassandra
 spec:
   selector:
     app.kubernetes.io/app: apache-cassandra
@@ -138,6 +140,10 @@ spec:
       protocol: TCP
       port: 9042
       targetPort: 9042
+    - name: exporter
+      protocol: TCP
+      port: 9000
+      targetPort: 9000
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
## Changes
* [Added exporter port to service, added label to allow ServiceMonitor to target the service](https://github.com/observIQ/charts/commit/85d1ae23b4b09996278262f27633af0f094d9ef5) 
* [bumped chart version to 0.0.10](https://github.com/observIQ/charts/commit/4618ee134597b91017aac68a0d77c49253786e7e)

## Details
For the `ServiceMonitor` resource to target the Apache Cassandra service correctly, a label has to be applied. We also will need the port for the exporter to be included in the service.