### PR TITLE
Cassandra: Fix deployment

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.10
+version: 0.0.11

--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.0.11
+version: 0.1.0

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -36,7 +36,7 @@ data:
       type: GAUGE
 
     # name is always the same, the name of the GC
-    - pattern: 'java.lang<type=GarbageCollector, name=[^,]+, key=([^>]+)><LastGcInfo, memoryUsageAfterGc>(used|commited): (\d+)'
+    - pattern: 'java.lang<type=GarbageCollector, name=[^,]+, key=([^>]+)><LastGcInfo, memoryUsageAfterGc>(used|committed): (\d+)'
       name: jvm_memory_after_gc_$2_bytes
       value: $3
       labels:


### PR DESCRIPTION
## Changes
* [updated tag and fixed typo in jmx configuration](https://github.com/observIQ/charts/commit/12ca757161d45d64ac87ab17766207617c1f4b7f)

## Details
After updating the tag from `0.0.9` -> `0.0.10` I saw some things revert after running `tk tool charts vendor` to pull the latest changes into the `cloud-onboarding` repo. I'm not 100% sure this will fix it, but I think it's worth a shot, my thought is that it might be equating `0.0.1` to `0.0.10` somehow and that `0.1.0` would be an easy way to solve the issue.