### PR TITLE
Aerospike: Update namespace for deployments

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.3
+version: 0.0.4

--- a/charts/aerospike/templates/configmaps.yaml
+++ b/charts/aerospike/templates/configmaps.yaml
@@ -18,7 +18,7 @@ data:
     network {
             service {
                     address any
-                    access-address aerospike-0.aerospike.default.svc.cluster.local
+                    access-address aerospike-0.aerospike.sample-apps.svc.cluster.local
                     port 3000
             }
 
@@ -26,9 +26,9 @@ data:
                     mode mesh
                     port 3002
 
-                    mesh-seed-address-port aerospike-0.aerospike.default.svc.cluster.local 3002
-                    mesh-seed-address-port aerospike-1.aerospike.default.svc.cluster.local 3002
-                    mesh-seed-address-port aerospike-2.aerospike.default.svc.cluster.local 3002
+                    mesh-seed-address-port aerospike-0.aerospike.sample-apps.svc.cluster.local 3002
+                    mesh-seed-address-port aerospike-1.aerospike.sample-apps.svc.cluster.local 3002
+                    mesh-seed-address-port aerospike-2.aerospike.sample-apps.svc.cluster.local 3002
 
                     interval 150
                     timeout 10

--- a/charts/aerospike/templates/loadgen.yaml
+++ b/charts/aerospike/templates/loadgen.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: aerospike-loadgen
-  namespace: default
+  namespace: sample-apps
 spec:
   schedule: "*/2 * * * *"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
## Changes
* [updated namespace in aerospike access address and mesh seed address](https://github.com/observIQ/charts/commit/999eb27f9507f62e67530bcdcd17b1f750f7ae5e)
* [bumped chart version to 0.0.4](https://github.com/observIQ/charts/commit/e1da0d040f5f9b86cbc6f144669cd018327ada8a)

## Details
The namespace in the `k3d` environment for sample applications is `sample-apps` and the deployment was failing in the `k3d` environment because the Aerospike configuration has the `default` namespace in the **access-address** and the **mesh-seed-address-port** values. Wanted to make this a value to be configured in `values.yaml` but it didn't seem like that would work.

Had to update the namespace for the loadgen deployment, as well.