### PR TITLE
Aerospike: Update load generation

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.4
+version: 0.0.5

--- a/charts/aerospike/templates/loadgen.yaml
+++ b/charts/aerospike/templates/loadgen.yaml
@@ -19,7 +19,7 @@ spec:
             image: {{ .Values.loadgenImage }}
             args:
               - -h
-              - aerospike.default.svc.cluster.local
+              - aerospike.sample-apps.svc.cluster.local
               - -k
               - "1000"
               - -w


### PR DESCRIPTION
## Changes
* [updated namespace for the loadgen in the args](https://github.com/observIQ/charts/commit/d3011badcda6487d206f82120636db385d72aa88)
* [bumped chart version to 0.0.5](https://github.com/observIQ/charts/commit/a478de4fbb2093e89dbf628889d111b3bfe9d70d)

## Details
The namespace in the in the `args` where the host is specified needs to be updated to `sample-apps` to work in the `k3d` environment. Bumped version to `0.0.5`. 