### PR TITLE
Cassandra: Added label `cassandra_cluster` to the service

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.1.0
+version: 0.1.1

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -124,6 +124,7 @@ metadata:
   name: apache-cassandra
   labels:
     app.kubernetes.io/service: apache-cassandra
+    cassandra_cluster: cassandra-cluster-0
 spec:
   selector:
     app.kubernetes.io/app: apache-cassandra

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -124,7 +124,7 @@ metadata:
   name: apache-cassandra
   labels:
     app.kubernetes.io/service: apache-cassandra
-    cassandra_cluster: cassandra-cluster-0
+    cassandra_cluster: test-cluster
 spec:
   selector:
     app.kubernetes.io/app: apache-cassandra


### PR DESCRIPTION
## Changes
* [added cassandra_cluster label to the service](https://github.com/observIQ/charts/commit/7c90e0b81658d186ff319a01de3fd835b5565d39)
* [bumped chart version to 0.1.1](https://github.com/observIQ/charts/commit/652c738f60ed44bde8c16f767cb357c0929b5ffb)

## Details
Added the `cassandra_cluster` label to the service. This is to allow the `ServiceMonitor` resource in the sample-app environment to include the label with the metrics it scrapes and sends to the local Grafana instance.