### PR TITLE
Aerospike: Add `aerospike_cluster` label to service

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.5
+version: 0.0.6

--- a/charts/aerospike/templates/service.yaml
+++ b/charts/aerospike/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: aerospike
+    aerospike_cluster: as-cluster-0
   name: aerospike
 spec:
   clusterIP: None


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [added aerospike cluster label to the service to allow serviceMonitor resource to add that label to metrics being scraped](https://github.com/observIQ/charts/commit/06ea214479d197abacdcdde9cfe451c3fac3320a)
* [bumped chart version to 0.0.6](https://github.com/observIQ/charts/pull/71/commits/bf06f8f1cae00591abdc20e845479d58469c06f0)

## Description of Changes

This change will allow the `ServiceMonitor` resource to target this label and add it to the metrics being scraped by the resource. This is necessary for the work we're doing around the integrations supporting the `k8s` plugin

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
