### PR TITLE
Cassandra: Loadgen Fix

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.1.1
+version: 0.1.2

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -246,5 +246,5 @@ spec:
             - /bin/sh
             - -c
             # ignore errors as to skip read validations when running on mixed mode
-            - /opt/cassandra/tools/bin/cassandra-stress - /opt/cassandra/tools/bin/cassandra-stress write n=1 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore &&  /opt/cassandra/tools/bin/cassandra-stress mixed n=100 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore
+            - /opt/cassandra/tools/bin/cassandra-stress write n=1 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore &&  /opt/cassandra/tools/bin/cassandra-stress mixed n=100 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore
           restartPolicy: Never

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -246,5 +246,5 @@ spec:
             - /bin/sh
             - -c
             # ignore errors as to skip read validations when running on mixed mode
-            - /opt/cassandra/tools/bin/cassandra-stress mixed n=100 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore
+            - /opt/cassandra/tools/bin/cassandra-stress - /opt/cassandra/tools/bin/cassandra-stress write n=1 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore &&  /opt/cassandra/tools/bin/cassandra-stress mixed n=100 -node 'apache-cassandra.sample-apps.svc.cluster.local:9042' -errors ignore
           restartPolicy: Never


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [updated loadgen due to mixed mode not working correctly](https://github.com/observIQ/charts/commit/391a6afe72f5f2f92b5f878d49e5cea2ee899b5a)
* [bumped chart version to 0.1.2](https://github.com/observIQ/charts/commit/67935eec3580d8f5ec8c02b398709df83aeb25a2)
* [fixed typo with the loadgen command](https://github.com/observIQ/charts/pull/73/commits/1926953b069190874e0f014005054cdee0ba7bb8)

## Description of Changes

Speculating, but it seems as though changes were made to the load generation on the `cloud-onboarding` side and at some point, I overwrote those changes when pulling in new changes from this chart. I could have opted to go with what was present, but I opted for what was the latest in the chart.

Not entirely sure yet, but it sounds like the `mixed` mode didn't actually work as expected and that's why it was updated.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
