### PR TITLE
New chart: Apache ActiveMQ

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
           - "apache-hadoop"
           - "varnish"
           - "aerospike"
+          - "apache-activemq"
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -24,6 +24,7 @@ jobs:
           - "couchbase-community"
           - "varnish-exporter"
           - "aerospike-benchmark"
+          - "apache-activemq-loadgen"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/apache-activemq/Chart.yaml
+++ b/charts/apache-activemq/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+appVersion: 5.18.2
+engine: gotpl
+home: https://github.com/observIQ/charts/tree/main/charts/aerospike
+keywords:
+  - community
+  - forum
+maintainers:
+  - name: observIQ
+name: apache-activemq
+sources:
+  - https://activemq.apache.org/components/classic/documentation
+version: 0.0.1

--- a/charts/apache-activemq/Chart.yaml
+++ b/charts/apache-activemq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: 5.18.2
 engine: gotpl
-home: https://github.com/observIQ/charts/tree/main/charts/aerospike
+home: https://github.com/observIQ/charts/tree/main/charts/apache-activemq
 keywords:
   - community
   - forum

--- a/charts/apache-activemq/templates/configmap.yaml
+++ b/charts/apache-activemq/templates/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jmx-exporter-config
+data:
+  config.yaml: |
+    hostPort: localhost:1099
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    blacklistObjectNames:
+      - "org.apache.activemq:clientId=*,*"
+    whitelistObjectNames:
+      - "org.apache.activemq:destinationType=Queue,*"
+      - "org.apache.activemq:destinationType=Topic,*"
+      - "org.apache.activemq:type=Broker,brokerName=*"
+      - "org.apache.activemq:type=Topic,brokerName=*"
+
+    rules:
+
+    - pattern: org.apache.activemq<type=Broker, brokerName=(\S*), destinationType=(\S*), destinationName=(\S*)><>(\w+)
+      name: activemq_$2_$4
+      attrNameSnakeCase: true
+      labels:
+        destination: $3
+
+    - pattern: org.apache.activemq<type=Broker, brokerName=(\S*)><>CurrentConnectionsCount
+      name: activemq_connections
+      type: GAUGE
+
+    - pattern: org.apache.activemq<type=Broker, brokerName=(\S*)><>Total(.*)Count
+      name: activemq_$2_total
+      type: COUNTER
+
+    - pattern: org.apache.activemq<type=Broker, brokerName=(\S*)><>(.*)PercentUsage
+      name: activemq_$2_usage_ratio
+      type: GAUGE
+      valueFactor: 0.01

--- a/charts/apache-activemq/templates/deployment.yaml
+++ b/charts/apache-activemq/templates/deployment.yaml
@@ -65,6 +65,6 @@ spec:
         spec:
           containers:
           - name: activemq-loadgen
-            image: bmedora/activemq-loadgen:test123
+            image: {{ .Values.loadGeneratorImage }}
             imagePullPolicy: IfNotPresent
           restartPolicy: Never

--- a/charts/apache-activemq/templates/deployment.yaml
+++ b/charts/apache-activemq/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activemq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: activemq
+  template:
+    metadata:
+      labels:
+        app: activemq
+    spec:
+      containers:
+      - name: activemq
+        image: {{ .Values.image }}
+        ports:
+          - containerPort: 1099
+            name: jmx
+          - containerPort: 8161
+            name: web-ui
+        env:
+          - name: ACTIVEMQ_JMX
+            value: "1099"
+          - name: ACTIVEMQ_OPTS
+            value: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+      - name: jmx-exporter
+        image: bitnami/jmx-exporter:0.19.0
+        command:
+          - java
+          - -jar
+          - jmx_prometheus_httpserver.jar
+        args:
+          - "9000" 
+          - config.yaml
+        ports:
+          - containerPort: 9000
+            name: prometheus
+        volumeMounts:
+        - mountPath: /opt/bitnami/jmx-exporter/config.yaml
+          subPath: config.yaml
+          name: jmx-exporter-config
+      volumes:
+      - name: jmx-exporter-config
+        configMap:
+          name: jmx-exporter-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: activemq-loadgen
+  namespace: default
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: activemq-loadgen
+            image: bmedora/activemq-loadgen:test123
+            imagePullPolicy: IfNotPresent
+          restartPolicy: Never

--- a/charts/apache-activemq/templates/service.yaml
+++ b/charts/apache-activemq/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: apache-activemq
+  name: apache-activemq
+spec:
+  clusterIP: None
+  ports:
+  - port: 8161
+    name: web-ui
+  - port: 3000
+    name: exporter
+  - port: 5672
+    name: amqp
+  selector:
+    app: activemq

--- a/charts/apache-activemq/values.yaml
+++ b/charts/apache-activemq/values.yaml
@@ -1,1 +1,2 @@
 image: apache/activemq-classic:5.18.2
+loadGeneratorImage: bmedora/activemq-loadgen:test123

--- a/charts/apache-activemq/values.yaml
+++ b/charts/apache-activemq/values.yaml
@@ -1,0 +1,1 @@
+image: apache/activemq-classic:5.18.2

--- a/container/apache-activemq-loadgen/Dockerfile
+++ b/container/apache-activemq-loadgen/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang AS build
+
+WORKDIR /app
+
+COPY go.mod go.sum receiver-producer.go ./
+
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -o /receiver-producer
+
+FROM alpine:latest
+WORKDIR /
+COPY --from=build /receiver-producer /receiver-producer
+
+ENTRYPOINT [ "/receiver-producer" ]

--- a/container/apache-activemq-loadgen/go.mod
+++ b/container/apache-activemq-loadgen/go.mod
@@ -1,0 +1,5 @@
+module activemq-amqp-loadgen
+
+go 1.21.0
+
+require github.com/Azure/go-amqp v1.0.2 // indirect

--- a/container/apache-activemq-loadgen/go.sum
+++ b/container/apache-activemq-loadgen/go.sum
@@ -1,0 +1,2 @@
+github.com/Azure/go-amqp v1.0.2 h1:zHCHId+kKC7fO8IkwyZJnWMvtRXhYC0VJtD0GYkHc6M=
+github.com/Azure/go-amqp v1.0.2/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=

--- a/container/apache-activemq-loadgen/receiver-producer.go
+++ b/container/apache-activemq-loadgen/receiver-producer.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	amqp "github.com/Azure/go-amqp"
+)
+
+const host = "apache-activemq"
+const topic = "topic://test-topic"
+const queue = "queue://test-queue"
+const port = "5672"
+const username = "admin"
+const password = "admin"
+
+// Helper for errors
+func failOnError(err error, msg string) {
+	if err != nil {
+		log.Fatalf("%s %s", msg, err)
+	}
+}
+
+func startQueueProducer(wg *sync.WaitGroup) {
+	defer wg.Done()
+	ctx := context.Background()
+
+	host_address := fmt.Sprintf("amqp://%s:%s@%s:%s", username, password, host, port)
+
+	// create connection
+	conn, err := amqp.Dial(ctx, host_address, nil)
+	failOnError(err, "Connection to server failed")
+	defer conn.Close()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	failOnError(err, "Failed to open a session.")
+
+	// Send a message
+	{
+		var count = 100
+		// Create a sender
+		sender, err := session.NewSender(ctx, queue, nil)
+		failOnError(err, "Failed to create new sender")
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+		for i := 0; i < count; i++ {
+			// Send message
+			err = sender.Send(ctx, amqp.NewMessage([]byte("Hello World!")), &amqp.SendOptions{})
+			failOnError(err, "Failed to send message")
+		}
+
+		sender.Close(ctx)
+		cancel()
+	}
+}
+
+func startTopicProducer(wg *sync.WaitGroup) {
+	defer wg.Done()
+	ctx := context.Background()
+
+	host_address := fmt.Sprintf("amqp://%s:%s@%s:%s", username, password, host, port)
+
+	// create connection
+	conn, err := amqp.Dial(ctx, host_address, nil)
+	failOnError(err, "Connection to server failed")
+	defer conn.Close()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	failOnError(err, "Failed to open a session.")
+
+	// Send a message
+	{
+		var count = 100
+		// Create a sender
+		sender, err := session.NewSender(ctx, topic, nil)
+		failOnError(err, "Failed to create new sender")
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+		for i := 0; i < count; i++ {
+			// Send message
+			err = sender.Send(ctx, amqp.NewMessage([]byte("Hello World!")), &amqp.SendOptions{})
+			failOnError(err, "Failed to send message")
+		}
+
+		sender.Close(ctx)
+		cancel()
+	}
+}
+
+func startQueueReceiver(wg *sync.WaitGroup) {
+	defer wg.Done()
+	ctx := context.Background()
+
+	host_address := fmt.Sprintf("amqp://%s:%s@%s:%s", username, password, host, port)
+
+	// create connection
+	conn, err := amqp.Dial(ctx, host_address, nil)
+	failOnError(err, "Connection to server failed")
+	defer conn.Close()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	failOnError(err, "Failed to open a session.")
+
+	// continuously read messages from a queue
+	{
+		// Create a receiver
+		receiver, err := session.NewReceiver(ctx, queue, &amqp.ReceiverOptions{})
+		failOnError(err, "Failed creating receiver link")
+		defer func() {
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			receiver.Close(ctx)
+			cancel()
+		}()
+
+		log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
+
+		for {
+			// receive next message
+			msg, err := receiver.Receive(ctx, nil)
+			if err != nil {
+				log.Fatal("Reading message from AMQP:", err)
+			}
+
+			// accept message
+			if err = receiver.AcceptMessage(context.Background(), msg); err != nil {
+				log.Fatalf("Failure accepting message: %v", err)
+			}
+
+			fmt.Printf("Message received: %s\n", msg.GetData())
+		}
+	}
+}
+
+func startTopicReceiver(wg *sync.WaitGroup) {
+	defer wg.Done()
+	ctx := context.Background()
+
+	host_address := fmt.Sprintf("amqp://%s:%s@%s:%s", username, password, host, port)
+
+	// create connection
+	conn, err := amqp.Dial(ctx, host_address, nil)
+	failOnError(err, "Connection to server failed")
+	defer conn.Close()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	failOnError(err, "Failed to open a session.")
+
+	// continuously read messages from a topic
+	{
+		// Create a receiver
+		receiver, err := session.NewReceiver(ctx, topic, &amqp.ReceiverOptions{})
+		failOnError(err, "Failed creating receiver link")
+		defer func() {
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			receiver.Close(ctx)
+			cancel()
+		}()
+
+		log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
+
+		for {
+			// receive next message
+			msg, err := receiver.Receive(ctx, nil)
+			if err != nil {
+				log.Fatal("Reading message from AMQP:", err)
+			}
+
+			// accept message
+			if err = receiver.AcceptMessage(context.Background(), msg); err != nil {
+				log.Fatalf("Failure accepting message: %v", err)
+			}
+
+			fmt.Printf("Message received: %s\n", msg.GetData())
+		}
+	}
+}
+
+func main() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go startTopicReceiver(&wg)
+	go startTopicProducer(&wg)
+	go startQueueReceiver(&wg)
+	go startQueueProducer(&wg)
+
+	fmt.Println("Waiting for goroutines to finish...")
+	wg.Wait()
+	fmt.Println("Done!")
+}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [created activemq deployment with loadgen](https://github.com/observIQ/charts/commit/3958c05c2e8acd06489f33af0529e845ac2e066f)
* [created dockerfile to build activemq loadgen container](https://github.com/observIQ/charts/commit/c16ee7d887e0ada2532988b14bb72e4f8d8b663c)
* [updated deployment to pull loadgen image from values yaml](https://github.com/observIQ/charts/commit/23295967fbf0e81f7e424dd7eac7010b76f7e655)

## Description of Changes

> There will be a follow up PR to update the image being pulled by the cronJob for load generation, as the image needs to be built by CI before we can include it here.

These changes aim to include a new chart for Apache ActiveMQ with load generation to be used as a sample application in the `grafana/cloud-onboarding` repository.

The deployment is a single instance of ActiveMQ behind a service. The load generation is a cronjob that utilizes the container being added by this PR. The container is built using a multi-stage Dockerfile that builds a client to produce messages for a queue and topic every so often. The module being used in the Go files is [Azure/amqp-go](https://pkg.go.dev/github.com/Azure/go-amqp#ReceiveOptions).

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
