### PR TITLE
ActiveMQ: Fix typo and add label to service

### DIFF
--- a/charts/apache-activemq/templates/service.yaml
+++ b/charts/apache-activemq/templates/service.yaml
@@ -3,13 +3,14 @@ kind: Service
 metadata:
   labels:
     app: apache-activemq
+    activemq_cluster: activemq-cluster-1
   name: apache-activemq
 spec:
   clusterIP: None
   ports:
   - port: 8161
     name: web-ui
-  - port: 3000
+  - port: 9000
     name: exporter
   - port: 5672
     name: amqp


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [added activemq_cluster label and fixed typo for metrics port](https://github.com/observIQ/charts/commit/587d488dba31d502a94a0454b2e716da23f3d88f)

## Description of Changes

The port for the exporter was incorrect and I am adding a label `activemq_cluster` for the sample application in the `cloud-onboarding` repository.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
