### PR TITLE
Cassandra: Fix JVM Garbage Collection Count metric

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.1.3
+version: 0.1.4

--- a/charts/cassandra/templates/configmap.yaml
+++ b/charts/cassandra/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
       valueFactor: 0.000001
 
     # java.lang<type=GarbageCollector, name=G1 Young Generation><>CollectionCount
-    - pattern: 'java.lang<type=GarbageCollector, name=([^>]+)><>CollectionCount: (\d+)'
+    - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><>CollectionCount: (\d+)'
       name: jvm_gc_collection_count
       value: $2
       labels:

--- a/container/cassandra/config.yaml
+++ b/container/cassandra/config.yaml
@@ -46,7 +46,7 @@ rules:
   valueFactor: 0.000001
 
 # java.lang<type=GarbageCollector, name=G1 Young Generation><>CollectionCount
-- pattern: 'java.lang<type=GarbageCollector, name=([^>]+)><>CollectionCount: (\d+)'
+- pattern: 'java.lang<name=([^>]+), type=GarbageCollector><>CollectionCount: (\d+)'
   name: jvm_gc_collection_count
   value: $2
   labels:


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [updated cassandra jmx exporter config and bumped chart version](https://github.com/observIQ/charts/commit/f2f5ce8c3e79046644cc1fdbc2182224f876507c)
* [Applied config changes to container config for future use](https://github.com/observIQ/charts/commit/8731d12056e5c2992cf71e6397f9c6ff84cb6e93)

## Description of Changes

Updated the JMX exporter config to correctly parse/export the `jvm_gc_collection_count` metric.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
