### PR TITLE
Cassandra: Move `cassandra_cluster` label to pod spec

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.1.4
+version: 0.1.5

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/app: apache-cassandra
+        cassandra_cluster: test-cluster
     spec:
       containers:
       - name: apache-cassandra

--- a/charts/cassandra/templates/service.yaml
+++ b/charts/cassandra/templates/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: apache-cassandra
   labels:
     app.kubernetes.io/service: apache-cassandra
-    cassandra_cluster: test-cluster
 spec:
   selector:
     app.kubernetes.io/app: apache-cassandra


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [moved cassandra_cluster label to pod spec, bumped chart version](https://github.com/observIQ/charts/commit/11160e3a3035c3079c3f93d77d1db559eded3df1)

## Description of Changes

This change is required for the sample application logs to be able to also get this label added to them. Originally it was on the `service` definition because the `ServiceMonitor` can target either a label on the service, or labels on the pods, to include those with metrics. The `PodLogs` resource can only utilize the `podTargetLabels` option, meaning that to use this label we either duplicate it, or move it. I've opted to move it, considering the `ServiceMonitor` resource can also utilize the `podTargetLabels` option. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
