### PR TITLE
ActiveMQ: Changes for k8s plugin support

### DIFF
--- a/charts/apache-activemq/Chart.yaml
+++ b/charts/apache-activemq/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-activemq
 sources:
   - https://activemq.apache.org/components/classic/documentation
-version: 0.0.4
+version: 0.0.5

--- a/charts/apache-activemq/templates/configmap.yaml
+++ b/charts/apache-activemq/templates/configmap.yaml
@@ -35,3 +35,19 @@ data:
       name: activemq_$2_usage_ratio
       type: GAUGE
       valueFactor: 0.01
+
+    - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><LastGcInfo>duration: (\d+)'
+      name: jvm_gc_duration_seconds
+      value: $2
+      labels:
+        name: $1
+      type: GAUGE
+      # Convert microseconds to seconds
+      valueFactor: 0.000001
+
+    - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><>CollectionCount: (\d+)'
+      name: jvm_gc_collection_count
+      value: $2
+      labels:
+        name: $1
+      type: GAUGE

--- a/charts/apache-activemq/templates/configmap.yaml
+++ b/charts/apache-activemq/templates/configmap.yaml
@@ -9,11 +9,6 @@ data:
     lowercaseOutputLabelNames: true
     blacklistObjectNames:
       - "org.apache.activemq:clientId=*,*"
-    whitelistObjectNames:
-      - "org.apache.activemq:destinationType=Queue,*"
-      - "org.apache.activemq:destinationType=Topic,*"
-      - "org.apache.activemq:type=Broker,brokerName=*"
-      - "org.apache.activemq:type=Topic,brokerName=*"
 
     rules:
 

--- a/charts/apache-activemq/templates/deployment.yaml
+++ b/charts/apache-activemq/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: activemq
+        activemq_cluster: activemq-cluster-1
     spec:
       containers:
       - name: activemq

--- a/charts/apache-activemq/templates/service.yaml
+++ b/charts/apache-activemq/templates/service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: apache-activemq
-    activemq_cluster: activemq-cluster-1
   name: apache-activemq
 spec:
   clusterIP: None


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [updated jmx config to collect garbage collection metrics](https://github.com/observIQ/charts/commit/7f92a258bbc586fadb99cdc936237a4368505bef)
* [moved activemq cluster label to the pod spec](https://github.com/observIQ/charts/commit/c76d8ed0ab6f91d719ef6d9e0e5b3259bd359956)
* [bumped chart version to 0.0.5](https://github.com/observIQ/charts/commit/b29e2a4eb1f83cb834311a297cfef0120767c3fa)
* [removed whitelistObjectNames to allow gc metrics through](https://github.com/observIQ/charts/commit/7d7a5effd517ef21518716a12c54cd81e2855113)

## Description of Changes

These changes are necessary for the sample application in the `cloud-onboarding` repo to support using the k8s plugin resources to collect metrics and logs. Previously the JMX configuration did not provide JVM Garbage Collection metrics, so that has also been updated.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
