### PR TITLE
Aerospike: k8s plugin support

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.6
+version: 0.0.7

--- a/charts/aerospike/templates/service.yaml
+++ b/charts/aerospike/templates/service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: aerospike
-    aerospike_cluster: as-cluster-0
   name: aerospike
 spec:
   clusterIP: None

--- a/charts/aerospike/templates/statefulset.yaml
+++ b/charts/aerospike/templates/statefulset.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: aerospike
+        aerospike_cluster: as-cluster-0
     spec:
       containers:
       - name: aerospike


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [moved aerospike_cluster label to pod spec](https://github.com/observIQ/charts/commit/080be40e6d684ebb2e0a2dbe1a1ff720ffe4aab5)
* [bumped chart version to 0.0.7](https://github.com/observIQ/charts/commit/40e476f44b201feaf8b850cb3b84a46eb61c5c1e)

## Description of Changes

Moved a label to the pod spec to make targeting the label possible for both the `ServiceMonitor` and `PodLogs` resources that scrape metrics/logs in the k3d environment.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
