### PR TITLE
ActiveMQ: Add second topic/queue to loadgen

### DIFF
--- a/container/apache-activemq-loadgen/receiver-producer.go
+++ b/container/apache-activemq-loadgen/receiver-producer.go
@@ -11,8 +11,10 @@ import (
 )
 
 const host = "apache-activemq"
-const topic = "topic://test-topic"
-const queue = "queue://test-queue"
+const topicOne = "topic://test-topic-1"
+const topicTwo = "topic://test-topic-2"
+const queueOne = "queue://test-queue-1"
+const queueTwo = "queue://test-queue-2"
 const port = "5672"
 const username = "admin"
 const password = "admin"
@@ -107,10 +109,15 @@ func main() {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	go startReceiver(topic, &wg)
-	go startProducer(topic, &wg)
-	go startReceiver(queue, &wg)
-	go startProducer(queue, &wg)
+	go startReceiver(topicOne, &wg)
+	go startProducer(topicOne, &wg)
+	go startReceiver(queueOne, &wg)
+	go startProducer(queueOne, &wg)
+
+	go startReceiver(topicTwo, &wg)
+	go startProducer(topicTwo, &wg)
+	go startReceiver(queueTwo, &wg)
+	go startProducer(queueTwo, &wg)
 
 	fmt.Println("Waiting for goroutines to finish...")
 	wg.Wait()


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [updated loadgen to use two topics and queues](https://github.com/observIQ/charts/commit/9af5a3edcaa070f619d6761001531ed6a9906cf4)

## Description of Changes

Updated the load generation to include two queues/topics.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
