### PR TITLE
Apache Cassandra: Update `cassandra_cluster` label

### DIFF
--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 1.0.0
+version: 1.0.1

--- a/charts/cassandra/templates/deployment.yaml
+++ b/charts/cassandra/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/app: apache-cassandra
-        cassandra_cluster: test-cluster
+        cassandra_cluster: operator:cassandra-cluster
     spec:
       containers:
       - name: apache-cassandra


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [updated cassandra_cluster label to help identify which agent is perfo…](https://github.com/observIQ/charts/commit/b869f1e9b36fa10b51923c87ac4bbf84dc73a434) 
* [bumped chart version to 1.0.1](https://github.com/observIQ/charts/commit/b62c26369868619bfe0806fa3e74714caac0bf70)

## Description of Changes

The ask was for the value of this label to be more helpful in identifying which agent in the `k3d` environment is performing scrapes for metrics/logs.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
