### PR TITLE
Containers: Add PrestoDB load generation

### DIFF
--- a/container/prestodb-loadgen/Dockerfile
+++ b/container/prestodb-loadgen/Dockerfile
@@ -1,0 +1,3 @@
+FROM ahanaio/prestodb-cli
+
+COPY prestodb-tpch.sql /opt

--- a/container/prestodb-loadgen/prestodb-tpch.sql
+++ b/container/prestodb-loadgen/prestodb-tpch.sql
@@ -1,0 +1,21 @@
+SELECT
+     l.returnflag,
+     l.linestatus,
+     sum(l.quantity)                                       AS sum_qty,
+     sum(l.extendedprice)                                  AS sum_base_price,
+     sum(l.extendedprice * (1 - l.discount))               AS sum_disc_price,
+     sum(l.extendedprice * (1 - l.discount) * (1 + l.tax)) AS sum_charge,
+     avg(l.quantity)                                       AS avg_qty,
+     avg(l.extendedprice)                                  AS avg_price,
+     avg(l.discount)                                       AS avg_disc,
+     count(*)                                              AS count_order
+FROM
+     tpch.sf1.lineitem AS l
+WHERE
+     l.shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+GROUP BY
+     l.returnflag,
+     l.linestatus
+ORDER BY
+     l.returnflag,
+     l.linestatus;


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [Added Dockerfile to create loadgen container for PrestoDB](https://github.com/observIQ/charts/commit/0065281f426c98a9e935edaa1a668487666b6370)

## Description of Changes

This Dockerfile here is simple, it starts from an existing container that has the `prestodb-cli` tool installed. We simply are including a SQL script that targets the TPCH connector/schemas. This TPCH schema generates data on the fly when being queried against, so it's useful here, as we don't really want to setup an entire separate backend storage solution to run queries against through PrestoDB.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
