### PR TITLE
Chart: Add PrestoDB chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
           - "varnish"
           - "aerospike"
           - "apache-activemq"
+          - "prestodb"
 
     runs-on: ubuntu-latest
     steps:

--- a/charts/prestodb/.helmignore
+++ b/charts/prestodb/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prestodb/Chart.yaml
+++ b/charts/prestodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: presto
-description: The official Helm chart for Presto
+description: Customized version of the official Helm chart for Presto
 type: application
 version: 0.1.0
 appVersion: "0.283"

--- a/charts/prestodb/Chart.yaml
+++ b/charts/prestodb/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: presto
+description: The official Helm chart for Presto
+type: application
+version: 0.1.0
+appVersion: "0.283"
+home: https://prestodb.io
+icon: https://prestodb.io/docs/current/_static/logo.png
+keywords:
+  - presto
+  - prestodb
+sources:
+  - https://github.com/prestodb/presto
+  - https://github.com/prestodb/presto-helm-charts

--- a/charts/prestodb/README.md
+++ b/charts/prestodb/README.md
@@ -1,0 +1,60 @@
+# Helm Chart for Presto
+[Presto](https://prestodb.io) is a Fast and Reliable SQL Engine for Data Analytics and the Open Lakehouse.
+
+## Introduction
+This chart bootstraps a [Presto](https://github.com/prestodb/presto) on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+- Kubernetes 1.23+
+- Helm 3
+
+## Add Presto charts Helm repo
+Use the following command to add Presto charts repository to Helm configuration:
+```shell
+$ helm repo add presto https://prestodb.io/presto-helm-charts
+```
+
+## Installing the Chart
+Install the chart with `my-presto` release name:
+```shell
+$ helm install my-presto presto/presto
+```
+
+## Uninstalling the Chart
+Uninstall `my-presto` release:
+```shell
+$ helm uninstall my-presto
+```
+
+## Configuration
+Refer default `values.yaml` file of the chart for all the possible config properties:
+```shell
+$ helm show values presto/presto
+```
+
+## Presto deployment modes
+The chart supports three Presto deployment modes: single, cluster and highly available cluster.
+
+### Single
+Minimal Presto deployment, where single pod acts as Coordinator and Worker.
+This mode can be used for experimentation and testing purposes in environments with limited resources.\
+The following command installs Presto in **single** mode:
+```shell
+$ helm install my-presto presto/presto --set mode=single
+```
+
+### Cluster
+Standard Presto deployment with one Coordinator and multiple Workers.
+The chart deploys Presto in cluster mode by default.\
+The following command installs Presto in **cluster** mode with 3 workers:
+```shell
+$ helm install my-presto presto/presto --set mode=cluster --set worker.replicas=3
+```
+
+### Highly Available Cluster
+Highly available Presto deployment with multiple Resource Managers, Coordinators and Workers.
+This mode allows to avoid single point of failure and mitigate coordinator bottleneck in high load Presto clusters.\
+The following command installs Presto in **ha-cluster** mode with 2 coordinators and 3 workers:
+```shell
+$ helm install my-presto presto/presto --set mode=ha-cluster --set coordinator.replicas=2 --set worker.replicas=3
+```

--- a/charts/prestodb/templates/NOTES.txt
+++ b/charts/prestodb/templates/NOTES.txt
@@ -1,0 +1,24 @@
+The chart has been installed!
+Please keep in mind that some time is needed for the release to be fully deployed.
+
+In order to check the release status, use:
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+    or for more detailed info
+  helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Accessing deployed release:
+- To access {{ .Release.Name }} service within the cluster, use the following URL:
+    {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+- To access {{ .Release.Name }} service from outside the cluster for debugging, run the following command:
+    kubectl port-forward svc/{{ .Release.Name }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  and then open the browser on 127.0.0.1:{{ .Values.service.port }}
+{{- if eq .Values.service.type "NodePort" }}
+- To access {{ .Release.Name }} service from outside the cluster through configured NodePort, run the following commands:
+    export NODE_PORT=$(kubectl get service {{ .Release.Name }} -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}")
+    export NODE_IP=$(kubectl get nodes -n {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo http://$NODE_IP:$NODE_PORT
+{{- end }}
+{{- if .Values.ingress.enabled }}
+- To access {{ .Release.Name }} service from outside the cluster through configured Ingress, use the following URL:
+    http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
+{{- end }}

--- a/charts/prestodb/templates/configmap-catalog.yaml
+++ b/charts/prestodb/templates/configmap-catalog.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prestodb-catalog
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{- range $name, $properties := .Values.catalog }}
+  {{ $name }}.properties: |-
+    {{- $properties | nindent 4 }}
+  {{- end }}

--- a/charts/prestodb/templates/configmap-coordinator.yaml
+++ b/charts/prestodb/templates/configmap-coordinator.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prestodb-coordinator
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: coordinator
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  node.properties: |-
+    node.location={{ .Values.node.location }}
+    node.environment={{ .Values.node.environment }}
+    node.data-dir={{ .Values.node.dataDir }}
+  jvm.config: |-
+    {{- .Values.coordinator.jvm | default .Values.jvm | nindent 4 }}
+  config.properties: |-
+    coordinator=true
+    http-server.http.port={{ .Values.service.port }}
+    discovery.uri=http://prestodb-discovery:{{ .Values.service.port }}
+    discovery-server.enabled={{ or (eq .Values.mode "single") (eq .Values.mode "cluster") }}
+    node-scheduler.include-coordinator={{ eq .Values.mode "single" }}
+    resource-manager-enabled={{ eq .Values.mode "ha-cluster" }}
+    {{- .Values.config | nindent 4 }}
+  log.properties: |-
+    {{- .Values.log | nindent 4 }}

--- a/charts/prestodb/templates/configmap-jmx.yaml
+++ b/charts/prestodb/templates/configmap-jmx.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-script
+data:
+  config.yaml: |
+    hostPort: localhost:9001
+    lowercaseOutputLabelNames: true
+    lowercaseOutputName: true
+    rules:
+    - pattern: ".*"

--- a/charts/prestodb/templates/configmap-resource-manager.yaml
+++ b/charts/prestodb/templates/configmap-resource-manager.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Values.mode "ha-cluster" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prestodb-resource-manager
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: resource-manager
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  node.properties: |-
+    node.location={{ .Values.node.location }}
+    node.environment={{ .Values.node.environment }}
+    node.data-dir={{ .Values.node.dataDir }}
+  jvm.config: |-
+    {{- .Values.resourceManager.jvm | default .Values.jvm | nindent 4 }}
+  config.properties: |-
+    coordinator=false
+    http-server.http.port={{ .Values.service.port }}
+    discovery.uri=http://prestodb-discovery:{{ .Values.service.port }}
+    discovery-server.enabled=true
+    node-scheduler.include-coordinator=false
+    resource-manager-enabled=true
+    resource-manager=true
+    thrift.server.port=8081
+    thrift.server.ssl.enabled=false
+    {{- .Values.config | nindent 4 }}
+  log.properties: |-
+    {{- .Values.log | nindent 4 }}
+{{- end }}

--- a/charts/prestodb/templates/configmap-worker.yaml
+++ b/charts/prestodb/templates/configmap-worker.yaml
@@ -1,0 +1,28 @@
+{{- if or (eq .Values.mode "cluster") (eq .Values.mode "ha-cluster") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prestodb-worker
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  node.properties: |-
+    node.location={{ .Values.node.location }}
+    node.environment={{ .Values.node.environment }}
+    node.data-dir={{ .Values.node.dataDir }}
+  jvm.config: |-
+    {{- .Values.worker.jvm | default .Values.jvm | nindent 4 }}
+  config.properties: |-
+    coordinator=false
+    http-server.http.port={{ .Values.service.port }}
+    discovery.uri=http://prestodb-discovery:{{ .Values.service.port }}
+    resource-manager-enabled={{ eq .Values.mode "ha-cluster" }}
+    {{- .Values.config | nindent 4 }}
+  log.properties: |-
+    {{- .Values.log | nindent 4 }}
+{{- end }}

--- a/charts/prestodb/templates/cronjob-loadgen.yaml
+++ b/charts/prestodb/templates/cronjob-loadgen.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: prestodb-loadgen
+  namespace: {{ .Values.loadgenNamespace }}
+spec:
+  schedule: "*/10 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: prestodb-cli
+            image: {{ .Values.loadgenImage }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - ./opt/presto-cli --server prestodb:8080 --catalog tpch --schema sf100 -f /opt/prestodb-tpch.sql
+          restartPolicy: Never

--- a/charts/prestodb/templates/deployment-coordinator.yaml
+++ b/charts/prestodb/templates/deployment-coordinator.yaml
@@ -1,0 +1,122 @@
+{{- $env := concat .Values.env .Values.coordinator.env }}
+{{- $envFrom := concat .Values.envFrom .Values.coordinator.envFrom }}
+{{- $volumes := concat .Values.volumes .Values.coordinator.volumes }}
+{{- $volumeMounts := concat .Values.volumeMounts .Values.coordinator.volumeMounts }}
+{{- $containers := concat .Values.containers .Values.coordinator.containers }}
+{{- $initContainers := concat .Values.initContainers .Values.coordinator.initContainers }}
+{{- $nodeSelector := or .Values.coordinator.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.coordinator.affinity .Values.affinity }}
+{{- $tolerations := or .Values.coordinator.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.coordinator.securityContext .Values.securityContext }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prestodb-coordinator
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: coordinator
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ eq .Values.mode "ha-cluster" | ternary .Values.coordinator.replicas 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: prestodb
+      app.kubernetes.io/component: coordinator
+  strategy: {{- toYaml .Values.coordinator.deployment.strategy | nindent 4 }}
+  revisionHistoryLimit: {{ toYaml .Values.coordinator.deployment.revisionHistoryLimit }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: prestodb
+        app.kubernetes.io/component: coordinator
+      annotations:
+        checksum/catalog: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        checksum/coordinator: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
+      {{- end }}
+      {{- with $initContainers }}
+      initContainers: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: coordinator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.coordinator.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.coordinator.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $env }}
+          env: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /v1/status
+              port: http
+            initialDelaySeconds: {{ .Values.coordinator.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.coordinator.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.coordinator.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.coordinator.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.coordinator.livenessProbe.successThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /v1/status
+              port: http
+            initialDelaySeconds: {{ .Values.coordinator.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.coordinator.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.coordinator.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.coordinator.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.coordinator.readinessProbe.successThreshold }}
+          {{- with .Values.coordinator.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: {{ .Values.home }}/etc
+              name: config
+            - mountPath: {{ .Values.home }}/etc/catalog
+              name: catalog
+            {{- with $volumeMounts }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+        {{- with $containers }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: prestodb-coordinator
+        - name: catalog
+          configMap:
+            name: prestodb-catalog
+        {{- with $volumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/prestodb/templates/deployment-resource-manager.yaml
+++ b/charts/prestodb/templates/deployment-resource-manager.yaml
@@ -1,0 +1,126 @@
+{{- $env := concat .Values.env .Values.resourceManager.env }}
+{{- $envFrom := concat .Values.envFrom .Values.resourceManager.envFrom }}
+{{- $volumes := concat .Values.volumes .Values.resourceManager.volumes }}
+{{- $volumeMounts := concat .Values.volumeMounts .Values.resourceManager.volumeMounts }}
+{{- $containers := concat .Values.containers .Values.resourceManager.containers }}
+{{- $initContainers := concat .Values.initContainers .Values.resourceManager.initContainers }}
+{{- $nodeSelector := or .Values.resourceManager.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.resourceManager.affinity .Values.affinity }}
+{{- $tolerations := or .Values.resourceManager.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.resourceManager.securityContext .Values.securityContext }}
+{{- if eq .Values.mode "ha-cluster" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prestodb-resource-manager
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: resource-manager
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ eq .Values.mode "ha-cluster" | ternary .Values.resourceManager.replicas 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: prestodb
+      app.kubernetes.io/component: resource-manager
+  strategy: {{- toYaml .Values.resourceManager.deployment.strategy | nindent 4 }}
+  revisionHistoryLimit: {{ toYaml .Values.resourceManager.deployment.revisionHistoryLimit }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: prestodb
+        app.kubernetes.io/component: resource-manager
+      annotations:
+        checksum/catalog: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        checksum/resource-manager: {{ include (print $.Template.BasePath "/configmap-resource-manager.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
+      {{- end }}
+      {{- with $initContainers }}
+      initContainers: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: resource-manager
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.resourceManager.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resourceManager.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $env }}
+          env: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            - name: thrift
+              containerPort: 8081
+          livenessProbe:
+            httpGet:
+              path: /v1/status
+              port: http
+            initialDelaySeconds: {{ .Values.resourceManager.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.resourceManager.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.resourceManager.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.resourceManager.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.resourceManager.livenessProbe.successThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /v1/status
+              port: http
+            initialDelaySeconds: {{ .Values.resourceManager.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.resourceManager.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.resourceManager.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.resourceManager.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.resourceManager.readinessProbe.successThreshold }}
+          {{- with .Values.resourceManager.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: {{ .Values.home }}/etc
+              name: config
+            - mountPath: {{ .Values.home }}/etc/catalog
+              name: catalog
+            {{- with $volumeMounts }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+        {{- with $containers }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: prestodb-resource-manager
+        - name: catalog
+          configMap:
+            name: prestodb-catalog
+        {{- with $volumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/prestodb/templates/deployment-worker.yaml
+++ b/charts/prestodb/templates/deployment-worker.yaml
@@ -1,0 +1,124 @@
+{{- $env := concat .Values.env .Values.worker.env }}
+{{- $envFrom := concat .Values.envFrom .Values.worker.envFrom }}
+{{- $volumes := concat .Values.volumes .Values.worker.volumes }}
+{{- $volumeMounts := concat .Values.volumeMounts .Values.worker.volumeMounts }}
+{{- $containers := concat .Values.containers .Values.worker.containers }}
+{{- $initContainers := concat .Values.initContainers .Values.worker.initContainers }}
+{{- $nodeSelector := or .Values.worker.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.worker.affinity .Values.affinity }}
+{{- $tolerations := or .Values.worker.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.worker.securityContext .Values.securityContext }}
+{{- if or (eq .Values.mode "cluster") (eq .Values.mode "ha-cluster") }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prestodb-worker
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: prestodb
+      app.kubernetes.io/component: worker
+  strategy: {{- toYaml .Values.worker.deployment.strategy | nindent 4 }}
+  revisionHistoryLimit: {{ toYaml .Values.worker.deployment.revisionHistoryLimit }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: prestodb
+        app.kubernetes.io/component: worker
+      annotations:
+        checksum/catalog: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        checksum/worker: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
+      {{- end }}
+      {{- with $initContainers }}
+      initContainers: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.worker.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $env }}
+          env: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /v1/status
+              port: http
+            initialDelaySeconds: {{ .Values.worker.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.worker.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.worker.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.worker.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.worker.livenessProbe.successThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /v1/status
+              port: http
+            initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.worker.readinessProbe.successThreshold }}
+          {{- with .Values.worker.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: {{ .Values.home }}/etc
+              name: config
+            - mountPath: {{ .Values.home }}/etc/catalog
+              name: catalog
+            {{- with $volumeMounts }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+        {{- with $containers }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: prestodb-worker
+        - name: catalog
+          configMap:
+            name: prestodb-catalog
+        {{- with $volumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/prestodb/templates/ingress.yaml
+++ b/charts/prestodb/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prestodb
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: prestodb
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/prestodb/templates/service-discovery.yaml
+++ b/charts/prestodb/templates/service-discovery.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prestodb-discovery
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: {{ eq .Values.mode "ha-cluster" | ternary "resource-manager" "coordinator" }}

--- a/charts/prestodb/templates/service.yaml
+++ b/charts/prestodb/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prestodb
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      targetPort: http
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/component: coordinator

--- a/charts/prestodb/templates/serviceaccount.yaml
+++ b/charts/prestodb/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: prestodb
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/prestodb/values.yaml
+++ b/charts/prestodb/values.yaml
@@ -1,0 +1,326 @@
+# Default values for presto
+loadgenImage: ahanaio/prestodb-cli
+loadgenNamespace: default
+
+image:
+  repository: prestodb/presto
+  pullPolicy: IfNotPresent
+  tag: ~
+
+imagePullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 8080
+  nodePort: ~
+  labels: {}
+  annotations: {}
+
+ingress:
+  enabled: true
+  labels: {}
+  annotations: {}
+  ingressClassName: ~
+  tls: []
+  host: presto.local
+  path: /
+  pathType: Prefix
+
+serviceAccount:
+  create: true
+  name: ~
+  labels: {}
+  annotations: {}
+
+# Common environment variables (templated)
+env: []
+# Common envFrom items to set up environment variables (templated)
+envFrom: []
+
+# Additional common volumes (templated)
+volumes: []
+# Additional common volumeMounts (templated)
+volumeMounts: []
+
+# Additional common init containers (templated)
+initContainers: []
+# Additional common containers (templated)
+containers: []
+
+# Constrain all presto pods to nodes with specific node labels
+nodeSelector: {}
+# Constrain all presto pods to nodes by affinity/anti-affinity rules
+affinity: {}
+# Allow to schedule all presto pods on nodes with matching taints
+tolerations: []
+
+# Security context by default
+securityContext: {}
+
+# Presto home directory
+home: /opt/presto-server
+
+# Deployment mode
+# single - Minimal Presto deployment where single pod acts as Coordinator and Worker
+# cluster - Standard Presto deployment with one Coordinator and multiple Workers
+# ha-cluster - Highly available Presto deployment with multiple Resource Managers, Coordinators and Workers
+mode: ha-cluster
+
+# Common node properties, see https://prestodb.io/docs/current/installation/deployment.html#node-properties
+node:
+  location: presto.local
+  environment: development
+  dataDir: /var/presto/data
+
+# Common JVM options, see https://prestodb.io/docs/current/installation/deployment.html#jvm-config
+jvm: |-
+  -server
+  -XX:+ExitOnOutOfMemoryError
+  -Djdk.attach.allowAttachSelf=true
+  -Dcom.sun.management.jmxremote
+  -Dcom.sun.management.jmxremote.port=9001
+  -Dcom.sun.management.jmxremote.authenticate=false
+  -Dcom.sun.management.jmxremote.ssl=false
+
+# Common configuration properties, see https://prestodb.io/docs/current/installation/deployment.html#config-properties
+config: |-
+  query.max-memory=1GB
+  query.max-memory-per-node=512MB
+
+# Common log-levels properties, see https://prestodb.io/docs/current/installation/deployment.html#log-levels
+log: |-
+  com.facebook.presto=INFO
+
+# Resource Manager configuration
+resourceManager:
+  # Number of resource managers in "ha-cluster" mode
+  replicas: 1
+  # Resource manager JVM options (overwrites common JVM options)
+  jvm: ""
+  # Command to launch resource manager (templated)
+  command: ["sh", "-c", "$PRESTO_HOME/bin/launcher run"]
+  # Arguments to launch resource manager (templated)
+  args: ~
+  # Additional resource manager environment variables (templated)
+  env: []
+  # Additional resource manager envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Additional resource manager volumes (templated)
+  volumes:
+  - name: config-script
+    configMap:
+      name: config-script
+      defaultMode: 0644
+      items:
+      - key: config.yaml
+        path: config.yaml
+  # Additional resource manager volumeMounts (templated)
+  volumeMounts: []
+  # Additional resource manager init containers (templated)
+  initContainers: []
+  # Additional resource manager containers (templated)
+  containers:
+  - name: jmx-exporter
+    image: bitnami/jmx-exporter:0.17.2
+    ports:
+    - name: exporter
+      containerPort: 9000
+    command:
+      - java
+      - -jar
+      - jmx_prometheus_httpserver.jar
+    args:
+      - "9000"
+      - config.yaml
+    volumeMounts:
+    - mountPath: /opt/bitnami/jmx-exporter/config.yaml
+      subPath: config.yaml
+      name: config-script
+  # Resource manager liveness probe
+  livenessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  # Resource manager readiness probe
+  readinessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  # Deployment configuration for resource manager
+  deployment:
+    strategy:
+      type: Recreate
+    revisionHistoryLimit: 3
+  # Resource manager resource limits and requests
+  resources: {}
+  # Constrain resource manager pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain resource manager pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule resource manager pods on nodes with matching taints
+  tolerations: []
+  # Resource manager security context (overwrites default security context)
+  securityContext: {}
+
+# Coordinator configuration
+coordinator:
+  # Number of coordinators in "ha-cluster" mode
+  replicas: 1
+  # Coordinator JVM options (overwrites common JVM options)
+  jvm: ""
+  # Command to launch coordinator (templated)
+  command: ["sh", "-c", "$PRESTO_HOME/bin/launcher run"]
+  # Arguments to launch coordinator (templated)
+  args: ~
+  # Additional coordinator environment variables (templated)
+  env: []
+  # Additional coordinator envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Additional coordinator volumes (templated)
+  volumes:
+  - name: config-script
+    configMap:
+      name: config-script
+      defaultMode: 0644
+      items:
+      - key: config.yaml
+        path: config.yaml
+  # Additional coordinator volumeMounts (templated)
+  volumeMounts: []
+  # Additional coordinator init containers (templated)
+  initContainers: []
+  # Additional coordinator containers (templated)
+  containers:
+  - name: jmx-exporter
+    image: bitnami/jmx-exporter:0.17.2
+    ports:
+    - name: exporter
+      containerPort: 9000
+    command:
+      - java
+      - -jar
+      - jmx_prometheus_httpserver.jar
+    args:
+      - "9000"
+      - config.yaml
+    volumeMounts:
+    - mountPath: /opt/bitnami/jmx-exporter/config.yaml
+      subPath: config.yaml
+      name: config-script
+  # Coordinator liveness probe
+  livenessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  # Coordinator readiness probe
+  readinessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  # Deployment configuration for coordinator
+  deployment:
+    strategy:
+      type: Recreate
+    revisionHistoryLimit: 3
+  # Coordinator resource limits and requests
+  resources: {}
+  # Constrain coordinator pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain coordinator pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule coordinator pods on nodes with matching taints
+  tolerations: []
+  # Coordinator security context (overwrites default security context)
+  securityContext: {}
+
+# Worker configuration
+worker:
+  # Number of workers in "cluster" and "ha-cluster" modes
+  replicas: 2
+  # Worker JVM options (overwrites common JVM options)
+  jvm: ""
+  # Command to launch worker (templated)
+  command: ["sh", "-c", "$PRESTO_HOME/bin/launcher run"]
+  # Arguments to launch worker (templated)
+  args: ~
+  # Additional worker environment variables (templated)
+  env: []
+  # Additional worker envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Additional worker volumes (templated)
+  volumes:
+  - name: config-script
+    configMap:
+      name: config-script
+      defaultMode: 0644
+      items:
+      - key: config.yaml
+        path: config.yaml
+  # Additional worker volumeMounts (templated)
+  volumeMounts: []
+  # Additional worker init containers (templated)
+  initContainers: []
+  # Additional worker containers (templated)
+  containers:
+  - name: jmx-exporter
+    image: bitnami/jmx-exporter:0.17.2
+    ports:
+    - name: exporter
+      containerPort: 9000
+    command:
+      - java
+      - -jar
+      - jmx_prometheus_httpserver.jar
+    args:
+      - "9000"
+      - config.yaml
+    volumeMounts:
+    - mountPath: /opt/bitnami/jmx-exporter/config.yaml
+      subPath: config.yaml
+      name: config-script
+  # Worker liveness probe
+  livenessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  # Worker readiness probe
+  readinessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  # Deployment configuration for worker
+  deployment:
+    strategy:
+      type: Recreate
+    revisionHistoryLimit: 3
+  # Worker resource limits and requests
+  resources: {}
+  # Constrain worker pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain worker pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule worker pods on nodes with matching taints
+  tolerations: []
+  # Worker security context (overwrites default security context)
+  securityContext: {}
+
+# Catalogs
+catalog:
+ jmx: |-
+   connector.name=jmx
+ tpch: |-
+   connector.name=tpch
+ tpcds: |-
+   connector.name=tpcds

--- a/charts/prestodb/values.yaml
+++ b/charts/prestodb/values.yaml
@@ -1,5 +1,5 @@
 # Default values for presto
-loadgenImage: ahanaio/prestodb-cli
+loadgenImage: docker pull ghcr.io/observiq/prestodb-loadgen:efea7c5
 loadgenNamespace: default
 
 image:


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [copied definitions from existing prestodb helm chart, added JMX exporter and a configmap for the exporter configuration](https://github.com/observIQ/charts/commit/2f9ba2c75366f6fda1d8116c9da3271613a607d8) 
* [updated the image being targeted for loadgenImage](https://github.com/observIQ/charts/commit/d78d1db2eb308898cde05261e7c5be2551ed1266)
* [added prestodb chart to release workflow](https://github.com/observIQ/charts/commit/c7bea93f92da7f01984cdfc9563c6eec64d25f6f)
* [updated description in Chart.yaml](https://github.com/observIQ/charts/commit/9ac1cd537e6a68591e20d0acb0e4b661eb2777e9)

## Description of Changes

This chart is based directly on the [official helm](https://github.com/prestodb/presto-helm-charts) chart that exists. It's been altered on our end to include the JMX exporter in each of the pods where metrics are scraped and load generation using a customized version of [this container](https://hub.docker.com/r/ahanaio/prestodb-cli).

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
