### PR TITLE
Presto: Add `prestodb_cluster` label

### DIFF
--- a/charts/prestodb/Chart.yaml
+++ b/charts/prestodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: presto
 description: Customized version of the official Helm chart for Presto
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.283"
 home: https://prestodb.io
 icon: https://prestodb.io/docs/current/_static/logo.png

--- a/charts/prestodb/templates/deployment-coordinator.yaml
+++ b/charts/prestodb/templates/deployment-coordinator.yaml
@@ -34,6 +34,7 @@ spec:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: prestodb
         app.kubernetes.io/component: coordinator
+        prestodb_cluster: operator-cluster
       annotations:
         checksum/catalog: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
         checksum/coordinator: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}

--- a/charts/prestodb/templates/deployment-resource-manager.yaml
+++ b/charts/prestodb/templates/deployment-resource-manager.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: prestodb
         app.kubernetes.io/component: resource-manager
+        prestodb_cluster: operator-cluster
       annotations:
         checksum/catalog: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
         checksum/resource-manager: {{ include (print $.Template.BasePath "/configmap-resource-manager.yaml") . | sha256sum }}

--- a/charts/prestodb/templates/deployment-worker.yaml
+++ b/charts/prestodb/templates/deployment-worker.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: prestodb
         app.kubernetes.io/component: worker
+        prestodb_cluster: operator-cluster
       annotations:
         checksum/catalog: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
         checksum/worker: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [added prestodb_cluster label to each deployment](https://github.com/observIQ/charts/commit/dd4944231b7aa83a2aecb607079c1e3dd3bc3959)
* [bumped chart version to 1.0.1](https://github.com/observIQ/charts/commit/b1a642ac946161162c7f73ea276a34b83445879b)

## Description of Changes

For each deployment (coordinator, resource manager, worker) we're adding the `prestodb_cluster` label to be used by the `PodLogs` and `ServiceMonitor` resources within the `k3d` environment.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
